### PR TITLE
Fix class inheritance issue in generated bindings, and aligned bindings with Yarp 3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,11 @@ option(YARP_USES_MATLAB "Do you want to create the MATLAB bindings" FALSE)
 option(YARP_USES_OCTAVE "Do you want to create the OCTAVE bindings" FALSE)
 option(YARP_GENERATE_MATLAB "Enable if you have the experimental version of SWIG necessary for generating the Matlab wrapper" FALSE)
 
-find_package(YARP 2.3.71 REQUIRED)
+find_package(YARP REQUIRED)
+set(YARP_REQUIRED_VERSION 3.0.0)
+if(${YARP_VERSION} VERSION_LESS ${YARP_REQUIRED_VERSION})
+  message(FATAL_ERROR "YARP version ${YARP_VERSION} not sufficient, at least version ${YARP_REQUIRED_VERSION} is required.")
+endif()
 
 # Check if YARP_WRAP_STL_STRING is defined in YARP
 get_target_property(YARP_SYSTEM_H_LOCATION YARP::YARP_conf INTERFACE_INCLUDE_DIRECTORIES)

--- a/matlab/autogenerated/+yarp/AbstractContactable.m
+++ b/matlab/autogenerated/+yarp/AbstractContactable.m
@@ -1,10 +1,7 @@
-classdef AbstractContactable < SwigRef
+classdef AbstractContactable < yarp.UnbufferedContactable
     %Usage: AbstractContactable ()
     %
   methods
-    function this = swig_this(self)
-      this = yarpMEX(3, self);
-    end
     function varargout = asPort(self,varargin)
     %Usage: retval = asPort ()
     %
@@ -217,6 +214,7 @@ classdef AbstractContactable < SwigRef
       end
     end
     function self = AbstractContactable(varargin)
+      self@yarp.UnbufferedContactable(SwigRef.Null);
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;

--- a/matlab/autogenerated/+yarp/AbstractContactable.m
+++ b/matlab/autogenerated/+yarp/AbstractContactable.m
@@ -6,210 +6,210 @@ classdef AbstractContactable < yarp.UnbufferedContactable
     %Usage: retval = asPort ()
     %
     %retval is of type Port. 
-      [varargout{1:nargout}] = yarpMEX(302, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(290, self, varargin{:});
     end
     function varargout = open(self,varargin)
     %Usage: retval = open (contact)
     %
     %contact is of type Contact. contact is of type Contact. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(303, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(291, self, varargin{:});
     end
     function varargout = addOutput(self,varargin)
     %Usage: retval = addOutput (contact)
     %
     %contact is of type Contact. contact is of type Contact. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(304, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(292, self, varargin{:});
     end
     function varargout = close(self,varargin)
     %Usage: close ()
     %
-      [varargout{1:nargout}] = yarpMEX(305, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(293, self, varargin{:});
     end
     function varargout = interrupt(self,varargin)
     %Usage: interrupt ()
     %
-      [varargout{1:nargout}] = yarpMEX(306, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(294, self, varargin{:});
     end
     function varargout = resume(self,varargin)
     %Usage: resume ()
     %
-      [varargout{1:nargout}] = yarpMEX(307, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(295, self, varargin{:});
     end
     function varargout = where(self,varargin)
     %Usage: retval = where ()
     %
     %retval is of type Contact. 
-      [varargout{1:nargout}] = yarpMEX(308, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(296, self, varargin{:});
     end
     function varargout = getName(self,varargin)
     %Usage: retval = getName ()
     %
     %retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(309, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(297, self, varargin{:});
     end
     function varargout = setEnvelope(self,varargin)
     %Usage: retval = setEnvelope (envelope)
     %
     %envelope is of type PortWriter. envelope is of type PortWriter. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(310, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(298, self, varargin{:});
     end
     function varargout = getEnvelope(self,varargin)
     %Usage: retval = getEnvelope (envelope)
     %
     %envelope is of type PortReader. envelope is of type PortReader. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(311, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(299, self, varargin{:});
     end
     function varargout = getInputCount(self,varargin)
     %Usage: retval = getInputCount ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(312, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(300, self, varargin{:});
     end
     function varargout = getOutputCount(self,varargin)
     %Usage: retval = getOutputCount ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(313, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(301, self, varargin{:});
     end
     function varargout = getReport(self,varargin)
     %Usage: getReport (reporter)
     %
     %reporter is of type PortReport. 
-      [varargout{1:nargout}] = yarpMEX(314, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(302, self, varargin{:});
     end
     function varargout = setReporter(self,varargin)
     %Usage: setReporter (reporter)
     %
     %reporter is of type PortReport. 
-      [varargout{1:nargout}] = yarpMEX(315, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(303, self, varargin{:});
     end
     function varargout = resetReporter(self,varargin)
     %Usage: resetReporter ()
     %
-      [varargout{1:nargout}] = yarpMEX(316, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(304, self, varargin{:});
     end
     function varargout = isWriting(self,varargin)
     %Usage: retval = isWriting ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(317, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(305, self, varargin{:});
     end
     function varargout = setReader(self,varargin)
     %Usage: setReader (reader)
     %
     %reader is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(318, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(306, self, varargin{:});
     end
     function varargout = setAdminReader(self,varargin)
     %Usage: setAdminReader (reader)
     %
     %reader is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(319, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(307, self, varargin{:});
     end
     function varargout = setInputMode(self,varargin)
     %Usage: setInputMode (expectInput)
     %
     %expectInput is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(320, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(308, self, varargin{:});
     end
     function varargout = setOutputMode(self,varargin)
     %Usage: setOutputMode (expectOutput)
     %
     %expectOutput is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(321, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(309, self, varargin{:});
     end
     function varargout = setRpcMode(self,varargin)
     %Usage: setRpcMode (expectRpc)
     %
     %expectRpc is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(322, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(310, self, varargin{:});
     end
     function varargout = getType(self,varargin)
     %Usage: retval = getType ()
     %
-    %retval is of type Type. 
-      [varargout{1:nargout}] = yarpMEX(323, self, varargin{:});
+    %retval is of type yarp::os::Type. 
+      [varargout{1:nargout}] = yarpMEX(311, self, varargin{:});
     end
     function varargout = promiseType(self,varargin)
     %Usage: promiseType (typ)
     %
-    %typ is of type Type const &. 
-      [varargout{1:nargout}] = yarpMEX(324, self, varargin{:});
+    %typ is of type yarp::os::Type const &. 
+      [varargout{1:nargout}] = yarpMEX(312, self, varargin{:});
     end
     function varargout = acquireProperties(self,varargin)
     %Usage: retval = acquireProperties (readOnly)
     %
     %readOnly is of type bool. readOnly is of type bool. retval is of type Property. 
-      [varargout{1:nargout}] = yarpMEX(325, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(313, self, varargin{:});
     end
     function varargout = releaseProperties(self,varargin)
     %Usage: releaseProperties (prop)
     %
     %prop is of type Property. 
-      [varargout{1:nargout}] = yarpMEX(326, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(314, self, varargin{:});
     end
     function varargout = write(self,varargin)
     %Usage: retval = write (writer, reader)
     %
     %writer is of type PortWriter. reader is of type PortReader. writer is of type PortWriter. reader is of type PortReader. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(327, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(315, self, varargin{:});
     end
     function varargout = read(self,varargin)
     %Usage: retval = read (reader)
     %
     %reader is of type PortReader. reader is of type PortReader. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(328, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(316, self, varargin{:});
     end
     function varargout = reply(self,varargin)
     %Usage: retval = reply (writer)
     %
     %writer is of type PortWriter. writer is of type PortWriter. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(329, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(317, self, varargin{:});
     end
     function varargout = replyAndDrop(self,varargin)
     %Usage: retval = replyAndDrop (writer)
     %
     %writer is of type PortWriter. writer is of type PortWriter. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(330, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(318, self, varargin{:});
     end
     function varargout = includeNodeInName(self,varargin)
     %Usage: includeNodeInName (flag)
     %
     %flag is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(331, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(319, self, varargin{:});
     end
     function varargout = setCallbackLock(self,varargin)
     %Usage: retval = setCallbackLock ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(332, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(320, self, varargin{:});
     end
     function varargout = removeCallbackLock(self,varargin)
     %Usage: retval = removeCallbackLock ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(333, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(321, self, varargin{:});
     end
     function varargout = lockCallback(self,varargin)
     %Usage: retval = lockCallback ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(334, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(322, self, varargin{:});
     end
     function varargout = tryLockCallback(self,varargin)
     %Usage: retval = tryLockCallback ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(335, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(323, self, varargin{:});
     end
     function varargout = unlockCallback(self,varargin)
     %Usage: unlockCallback ()
     %
-      [varargout{1:nargout}] = yarpMEX(336, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(324, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(337, self);
+        yarpMEX(325, self);
         self.SwigClear();
       end
     end

--- a/matlab/autogenerated/+yarp/BOTTLE_TAG_DOUBLE.m
+++ b/matlab/autogenerated/+yarp/BOTTLE_TAG_DOUBLE.m
@@ -1,3 +1,3 @@
 function v = BOTTLE_TAG_DOUBLE()
-  v = yarpMEX(420);
+  v = yarpMEX(408);
 end

--- a/matlab/autogenerated/+yarp/BOTTLE_TAG_INT.m
+++ b/matlab/autogenerated/+yarp/BOTTLE_TAG_INT.m
@@ -1,3 +1,3 @@
 function v = BOTTLE_TAG_INT()
-  v = yarpMEX(421);
+  v = yarpMEX(409);
 end

--- a/matlab/autogenerated/+yarp/BVector.m
+++ b/matlab/autogenerated/+yarp/BVector.m
@@ -9,89 +9,89 @@ classdef BVector < SwigRef
     %Usage: retval = pop ()
     %
     %retval is of type std::vector< bool >::value_type. 
-      [varargout{1:nargout}] = yarpMEX(1812, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1798, self, varargin{:});
     end
     function varargout = brace(self,varargin)
     %Usage: retval = brace (i)
     %
     %i is of type std::vector< bool >::difference_type. i is of type std::vector< bool >::difference_type. retval is of type std::vector< bool >::value_type. 
-      [varargout{1:nargout}] = yarpMEX(1813, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1799, self, varargin{:});
     end
     function varargout = setbrace(self,varargin)
     %Usage: setbrace (x, i)
     %
     %x is of type std::vector< bool >::value_type. i is of type std::vector< bool >::difference_type. 
-      [varargout{1:nargout}] = yarpMEX(1814, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1800, self, varargin{:});
     end
     function varargout = append(self,varargin)
     %Usage: append (x)
     %
     %x is of type std::vector< bool >::value_type. 
-      [varargout{1:nargout}] = yarpMEX(1815, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1801, self, varargin{:});
     end
     function varargout = empty(self,varargin)
     %Usage: retval = empty ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1816, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1802, self, varargin{:});
     end
     function varargout = size(self,varargin)
     %Usage: retval = size ()
     %
     %retval is of type std::vector< bool >::size_type. 
-      [varargout{1:nargout}] = yarpMEX(1817, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1803, self, varargin{:});
     end
     function varargout = swap(self,varargin)
     %Usage: swap (v)
     %
     %v is of type BVector. 
-      [varargout{1:nargout}] = yarpMEX(1818, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1804, self, varargin{:});
     end
     function varargout = begin(self,varargin)
     %Usage: retval = begin ()
     %
     %retval is of type std::vector< bool >::iterator. 
-      [varargout{1:nargout}] = yarpMEX(1819, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1805, self, varargin{:});
     end
     function varargout = end(self,varargin)
     %Usage: retval = end ()
     %
     %retval is of type std::vector< bool >::iterator. 
-      [varargout{1:nargout}] = yarpMEX(1820, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1806, self, varargin{:});
     end
     function varargout = rbegin(self,varargin)
     %Usage: retval = rbegin ()
     %
     %retval is of type std::vector< bool >::reverse_iterator. 
-      [varargout{1:nargout}] = yarpMEX(1821, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1807, self, varargin{:});
     end
     function varargout = rend(self,varargin)
     %Usage: retval = rend ()
     %
     %retval is of type std::vector< bool >::reverse_iterator. 
-      [varargout{1:nargout}] = yarpMEX(1822, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1808, self, varargin{:});
     end
     function varargout = clear(self,varargin)
     %Usage: clear ()
     %
-      [varargout{1:nargout}] = yarpMEX(1823, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1809, self, varargin{:});
     end
     function varargout = get_allocator(self,varargin)
     %Usage: retval = get_allocator ()
     %
     %retval is of type std::vector< bool >::allocator_type. 
-      [varargout{1:nargout}] = yarpMEX(1824, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1810, self, varargin{:});
     end
     function varargout = pop_back(self,varargin)
     %Usage: pop_back ()
     %
-      [varargout{1:nargout}] = yarpMEX(1825, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1811, self, varargin{:});
     end
     function varargout = erase(self,varargin)
     %Usage: retval = erase (first, last)
     %
     %first is of type std::vector< bool >::iterator. last is of type std::vector< bool >::iterator. first is of type std::vector< bool >::iterator. last is of type std::vector< bool >::iterator. retval is of type std::vector< bool >::iterator. 
-      [varargout{1:nargout}] = yarpMEX(1826, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1812, self, varargin{:});
     end
     function self = BVector(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -99,7 +99,7 @@ classdef BVector < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(1827, varargin{:});
+        tmp = yarpMEX(1813, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
@@ -108,53 +108,53 @@ classdef BVector < SwigRef
     %Usage: push_back (x)
     %
     %x is of type std::vector< bool >::value_type. 
-      [varargout{1:nargout}] = yarpMEX(1828, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1814, self, varargin{:});
     end
     function varargout = front(self,varargin)
     %Usage: retval = front ()
     %
     %retval is of type std::vector< bool >::value_type. 
-      [varargout{1:nargout}] = yarpMEX(1829, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1815, self, varargin{:});
     end
     function varargout = back(self,varargin)
     %Usage: retval = back ()
     %
     %retval is of type std::vector< bool >::value_type. 
-      [varargout{1:nargout}] = yarpMEX(1830, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1816, self, varargin{:});
     end
     function varargout = assign(self,varargin)
     %Usage: assign (n, x)
     %
     %n is of type std::vector< bool >::size_type. x is of type std::vector< bool >::value_type. 
-      [varargout{1:nargout}] = yarpMEX(1831, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1817, self, varargin{:});
     end
     function varargout = resize(self,varargin)
     %Usage: resize (new_size, x)
     %
     %new_size is of type std::vector< bool >::size_type. x is of type std::vector< bool >::value_type. 
-      [varargout{1:nargout}] = yarpMEX(1832, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1818, self, varargin{:});
     end
     function varargout = insert(self,varargin)
     %Usage: insert (pos, n, x)
     %
     %pos is of type std::vector< bool >::iterator. n is of type std::vector< bool >::size_type. x is of type std::vector< bool >::value_type. 
-      [varargout{1:nargout}] = yarpMEX(1833, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1819, self, varargin{:});
     end
     function varargout = reserve(self,varargin)
     %Usage: reserve (n)
     %
     %n is of type std::vector< bool >::size_type. 
-      [varargout{1:nargout}] = yarpMEX(1834, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1820, self, varargin{:});
     end
     function varargout = capacity(self,varargin)
     %Usage: retval = capacity ()
     %
     %retval is of type std::vector< bool >::size_type. 
-      [varargout{1:nargout}] = yarpMEX(1835, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1821, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1836, self);
+        yarpMEX(1822, self);
         self.SwigClear();
       end
     end

--- a/matlab/autogenerated/+yarp/Bottle.m
+++ b/matlab/autogenerated/+yarp/Bottle.m
@@ -13,229 +13,229 @@ classdef Bottle < yarp.Portable & yarp.Searchable
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(422, varargin{:});
+        tmp = yarpMEX(410, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(423, self);
+        yarpMEX(411, self);
         self.SwigClear();
       end
     end
     function varargout = clear(self,varargin)
     %Usage: clear ()
     %
-      [varargout{1:nargout}] = yarpMEX(424, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(412, self, varargin{:});
     end
     function varargout = addInt(self,varargin)
     %Usage: addInt (x)
     %
     %x is of type int. 
-      [varargout{1:nargout}] = yarpMEX(425, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(413, self, varargin{:});
     end
     function varargout = addInt8(self,varargin)
     %Usage: addInt8 (x)
     %
     %x is of type std::int8_t. 
-      [varargout{1:nargout}] = yarpMEX(426, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(414, self, varargin{:});
     end
     function varargout = addInt16(self,varargin)
     %Usage: addInt16 (x)
     %
     %x is of type std::int16_t. 
-      [varargout{1:nargout}] = yarpMEX(427, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(415, self, varargin{:});
     end
     function varargout = addInt32(self,varargin)
     %Usage: addInt32 (x)
     %
     %x is of type std::int32_t. 
-      [varargout{1:nargout}] = yarpMEX(428, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(416, self, varargin{:});
     end
     function varargout = addInt64(self,varargin)
     %Usage: addInt64 (x)
     %
     %x is of type std::int64_t. 
-      [varargout{1:nargout}] = yarpMEX(429, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(417, self, varargin{:});
     end
     function varargout = addVocab(self,varargin)
     %Usage: addVocab (x)
     %
     %x is of type int. 
-      [varargout{1:nargout}] = yarpMEX(430, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(418, self, varargin{:});
     end
     function varargout = addDouble(self,varargin)
     %Usage: addDouble (x)
     %
     %x is of type double. 
-      [varargout{1:nargout}] = yarpMEX(431, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(419, self, varargin{:});
     end
     function varargout = addFloat32(self,varargin)
     %Usage: addFloat32 (x)
     %
     %x is of type yarp::conf::float32_t. 
-      [varargout{1:nargout}] = yarpMEX(432, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(420, self, varargin{:});
     end
     function varargout = addFloat64(self,varargin)
     %Usage: addFloat64 (x)
     %
     %x is of type yarp::conf::float64_t. 
-      [varargout{1:nargout}] = yarpMEX(433, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(421, self, varargin{:});
     end
     function varargout = addString(self,varargin)
     %Usage: addString (str)
     %
     %str is of type std::string const &. 
-      [varargout{1:nargout}] = yarpMEX(434, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(422, self, varargin{:});
     end
     function varargout = add(self,varargin)
     %Usage: add (value)
     %
     %value is of type Value. 
-      [varargout{1:nargout}] = yarpMEX(435, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(423, self, varargin{:});
     end
     function varargout = addList(self,varargin)
     %Usage: retval = addList ()
     %
     %retval is of type Bottle. 
-      [varargout{1:nargout}] = yarpMEX(436, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(424, self, varargin{:});
     end
     function varargout = addDict(self,varargin)
     %Usage: retval = addDict ()
     %
     %retval is of type Property. 
-      [varargout{1:nargout}] = yarpMEX(437, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(425, self, varargin{:});
     end
     function varargout = pop(self,varargin)
     %Usage: retval = pop ()
     %
     %retval is of type Value. 
-      [varargout{1:nargout}] = yarpMEX(438, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(426, self, varargin{:});
     end
     function varargout = get(self,varargin)
     %Usage: retval = get (index)
     %
     %index is of type size_t. index is of type size_t. retval is of type Value. 
-      [varargout{1:nargout}] = yarpMEX(439, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(427, self, varargin{:});
     end
     function varargout = size(self,varargin)
     %Usage: retval = size ()
     %
     %retval is of type size_t. 
-      [varargout{1:nargout}] = yarpMEX(440, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(428, self, varargin{:});
     end
     function varargout = fromString(self,varargin)
     %Usage: fromString (text)
     %
     %text is of type std::string const &. 
-      [varargout{1:nargout}] = yarpMEX(441, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(429, self, varargin{:});
     end
     function varargout = fromBinary(self,varargin)
     %Usage: fromBinary (buf, len)
     %
     %buf is of type char const *. len is of type size_t. 
-      [varargout{1:nargout}] = yarpMEX(442, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(430, self, varargin{:});
     end
     function varargout = toBinary(self,varargin)
     %Usage: retval = toBinary ()
     %
     %retval is of type char const *. 
-      [varargout{1:nargout}] = yarpMEX(443, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(431, self, varargin{:});
     end
     function varargout = toString_c(self,varargin)
     %Usage: retval = toString_c ()
     %
     %retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(444, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(432, self, varargin{:});
     end
     function varargout = write(self,varargin)
     %Usage: retval = write (reader)
     %
     %reader is of type PortReader. reader is of type PortReader. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(445, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(433, self, varargin{:});
     end
     function varargout = read(self,varargin)
     %Usage: retval = read (writer)
     %
     %writer is of type PortWriter. writer is of type PortWriter. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(446, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(434, self, varargin{:});
     end
     function varargout = onCommencement(self,varargin)
     %Usage: onCommencement ()
     %
-      [varargout{1:nargout}] = yarpMEX(447, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(435, self, varargin{:});
     end
     function varargout = check(self,varargin)
     %Usage: retval = check (key)
     %
     %key is of type std::string const &. key is of type std::string const &. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(448, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(436, self, varargin{:});
     end
     function varargout = find(self,varargin)
     %Usage: retval = find (key)
     %
     %key is of type std::string const &. key is of type std::string const &. retval is of type Value. 
-      [varargout{1:nargout}] = yarpMEX(449, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(437, self, varargin{:});
     end
     function varargout = findGroup(self,varargin)
     %Usage: retval = findGroup (key)
     %
     %key is of type std::string const &. key is of type std::string const &. retval is of type Bottle. 
-      [varargout{1:nargout}] = yarpMEX(450, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(438, self, varargin{:});
     end
     function varargout = isNull(self,varargin)
     %Usage: retval = isNull ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(451, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(439, self, varargin{:});
     end
     function varargout = copy(self,varargin)
     %Usage: copy (alt)
     %
     %alt is of type Bottle. 
-      [varargout{1:nargout}] = yarpMEX(452, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(440, self, varargin{:});
     end
     function varargout = isEqual(self,varargin)
     %Usage: retval = isEqual (alt)
     %
     %alt is of type Bottle. alt is of type Bottle. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(454, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(442, self, varargin{:});
     end
     function varargout = notEqual(self,varargin)
     %Usage: retval = notEqual (alt)
     %
     %alt is of type Bottle. alt is of type Bottle. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(455, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(443, self, varargin{:});
     end
     function varargout = append(self,varargin)
     %Usage: append (alt)
     %
     %alt is of type Bottle. 
-      [varargout{1:nargout}] = yarpMEX(456, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(444, self, varargin{:});
     end
     function varargout = tail(self,varargin)
     %Usage: retval = tail ()
     %
     %retval is of type Bottle. 
-      [varargout{1:nargout}] = yarpMEX(457, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(445, self, varargin{:});
     end
     function varargout = hasChanged(self,varargin)
     %Usage: hasChanged ()
     %
-      [varargout{1:nargout}] = yarpMEX(458, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(446, self, varargin{:});
     end
     function varargout = getSpecialization(self,varargin)
     %Usage: retval = getSpecialization ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(459, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(447, self, varargin{:});
     end
     function varargout = toString(self,varargin)
     %Usage: retval = toString ()
     %
     %retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(461, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(449, self, varargin{:});
     end
   end
   methods(Static)
@@ -243,13 +243,13 @@ classdef Bottle < yarp.Portable & yarp.Searchable
     %Usage: retval = getNullBottle ()
     %
     %retval is of type Bottle. 
-     [varargout{1:nargout}] = yarpMEX(453, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(441, varargin{:});
     end
     function varargout = describeBottleCode(varargin)
     %Usage: retval = describeBottleCode (code)
     %
     %code is of type int. code is of type int. retval is of type std::string. 
-     [varargout{1:nargout}] = yarpMEX(460, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(448, varargin{:});
     end
   end
 end

--- a/matlab/autogenerated/+yarp/Bottle.m
+++ b/matlab/autogenerated/+yarp/Bottle.m
@@ -1,4 +1,4 @@
-classdef Bottle < SwigRef
+classdef Bottle < yarp.Portable & yarp.Searchable
     %Usage: Bottle ()
     %
   methods
@@ -6,6 +6,8 @@ classdef Bottle < SwigRef
       this = yarpMEX(3, self);
     end
     function self = Bottle(varargin)
+      self@yarp.Portable(SwigRef.Null);
+      self@yarp.Searchable(SwigRef.Null);
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;

--- a/matlab/autogenerated/+yarp/BottleCallback.m
+++ b/matlab/autogenerated/+yarp/BottleCallback.m
@@ -7,7 +7,7 @@ classdef BottleCallback < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(806, self);
+        yarpMEX(792, self);
         self.SwigClear();
       end
     end
@@ -15,7 +15,7 @@ classdef BottleCallback < SwigRef
     %Usage: onRead (datum, reader)
     %
     %datum is of type Bottle. reader is of type TypedReaderBottle. 
-      [varargout{1:nargout}] = yarpMEX(807, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(793, self, varargin{:});
     end
     function self = BottleCallback(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -23,7 +23,7 @@ classdef BottleCallback < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(808, varargin{:});
+        tmp = yarpMEX(794, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end

--- a/matlab/autogenerated/+yarp/BufferedPortBottle.m
+++ b/matlab/autogenerated/+yarp/BufferedPortBottle.m
@@ -14,14 +14,14 @@ classdef BufferedPortBottle < yarp.Contactable & yarp.TypedReaderBottle & yarp.B
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(809, varargin{:});
+        tmp = yarpMEX(795, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(810, self);
+        yarpMEX(796, self);
         self.SwigClear();
       end
     end
@@ -29,266 +29,266 @@ classdef BufferedPortBottle < yarp.Contactable & yarp.TypedReaderBottle & yarp.B
     %Usage: retval = addOutput (contact)
     %
     %contact is of type Contact. contact is of type Contact. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(811, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(797, self, varargin{:});
     end
     function varargout = close(self,varargin)
     %Usage: close ()
     %
-      [varargout{1:nargout}] = yarpMEX(812, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(798, self, varargin{:});
     end
     function varargout = interrupt(self,varargin)
     %Usage: interrupt ()
     %
-      [varargout{1:nargout}] = yarpMEX(813, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(799, self, varargin{:});
     end
     function varargout = resume(self,varargin)
     %Usage: resume ()
     %
-      [varargout{1:nargout}] = yarpMEX(814, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(800, self, varargin{:});
     end
     function varargout = getPendingReads(self,varargin)
     %Usage: retval = getPendingReads ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(815, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(801, self, varargin{:});
     end
     function varargout = where(self,varargin)
     %Usage: retval = where ()
     %
     %retval is of type Contact. 
-      [varargout{1:nargout}] = yarpMEX(816, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(802, self, varargin{:});
     end
     function varargout = getName(self,varargin)
     %Usage: retval = getName ()
     %
     %retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(817, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(803, self, varargin{:});
     end
     function varargout = prepare(self,varargin)
     %Usage: retval = prepare ()
     %
     %retval is of type Bottle. 
-      [varargout{1:nargout}] = yarpMEX(818, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(804, self, varargin{:});
     end
     function varargout = unprepare(self,varargin)
     %Usage: retval = unprepare ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(819, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(805, self, varargin{:});
     end
     function varargout = write(self,varargin)
     %Usage: write ()
     %
-      [varargout{1:nargout}] = yarpMEX(820, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(806, self, varargin{:});
     end
     function varargout = writeStrict(self,varargin)
     %Usage: writeStrict ()
     %
-      [varargout{1:nargout}] = yarpMEX(821, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(807, self, varargin{:});
     end
     function varargout = waitForWrite(self,varargin)
     %Usage: waitForWrite ()
     %
-      [varargout{1:nargout}] = yarpMEX(822, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(808, self, varargin{:});
     end
     function varargout = setStrict(self,varargin)
     %Usage: setStrict ()
     %
-      [varargout{1:nargout}] = yarpMEX(823, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(809, self, varargin{:});
     end
     function varargout = read(self,varargin)
     %Usage: retval = read ()
     %
     %retval is of type Bottle. 
-      [varargout{1:nargout}] = yarpMEX(824, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(810, self, varargin{:});
     end
     function varargout = lastRead(self,varargin)
     %Usage: retval = lastRead ()
     %
     %retval is of type Bottle. 
-      [varargout{1:nargout}] = yarpMEX(825, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(811, self, varargin{:});
     end
     function varargout = isClosed(self,varargin)
     %Usage: retval = isClosed ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(826, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(812, self, varargin{:});
     end
     function varargout = setReplier(self,varargin)
     %Usage: setReplier (reader)
     %
     %reader is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(827, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(813, self, varargin{:});
     end
     function varargout = setReader(self,varargin)
     %Usage: setReader (reader)
     %
     %reader is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(828, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(814, self, varargin{:});
     end
     function varargout = setAdminReader(self,varargin)
     %Usage: setAdminReader (reader)
     %
     %reader is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(829, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(815, self, varargin{:});
     end
     function varargout = onRead(self,varargin)
     %Usage: onRead (datum)
     %
     %datum is of type Bottle. 
-      [varargout{1:nargout}] = yarpMEX(830, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(816, self, varargin{:});
     end
     function varargout = useCallback(self,varargin)
     %Usage: useCallback ()
     %
-      [varargout{1:nargout}] = yarpMEX(831, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(817, self, varargin{:});
     end
     function varargout = disableCallback(self,varargin)
     %Usage: disableCallback ()
     %
-      [varargout{1:nargout}] = yarpMEX(832, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(818, self, varargin{:});
     end
     function varargout = setEnvelope(self,varargin)
     %Usage: retval = setEnvelope (envelope)
     %
     %envelope is of type PortWriter. envelope is of type PortWriter. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(833, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(819, self, varargin{:});
     end
     function varargout = getEnvelope(self,varargin)
     %Usage: retval = getEnvelope (envelope)
     %
     %envelope is of type PortReader. envelope is of type PortReader. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(834, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(820, self, varargin{:});
     end
     function varargout = getInputCount(self,varargin)
     %Usage: retval = getInputCount ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(835, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(821, self, varargin{:});
     end
     function varargout = getOutputCount(self,varargin)
     %Usage: retval = getOutputCount ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(836, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(822, self, varargin{:});
     end
     function varargout = isWriting(self,varargin)
     %Usage: retval = isWriting ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(837, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(823, self, varargin{:});
     end
     function varargout = getReport(self,varargin)
     %Usage: getReport (reporter)
     %
     %reporter is of type PortReport. 
-      [varargout{1:nargout}] = yarpMEX(838, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(824, self, varargin{:});
     end
     function varargout = setReporter(self,varargin)
     %Usage: setReporter (reporter)
     %
     %reporter is of type PortReport. 
-      [varargout{1:nargout}] = yarpMEX(839, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(825, self, varargin{:});
     end
     function varargout = resetReporter(self,varargin)
     %Usage: resetReporter ()
     %
-      [varargout{1:nargout}] = yarpMEX(840, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(826, self, varargin{:});
     end
     function varargout = acquire(self,varargin)
     %Usage: retval = acquire ()
     %
     %retval is of type void *. 
-      [varargout{1:nargout}] = yarpMEX(841, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(827, self, varargin{:});
     end
     function varargout = release(self,varargin)
     %Usage: release (handle)
     %
     %handle is of type void *. 
-      [varargout{1:nargout}] = yarpMEX(842, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(828, self, varargin{:});
     end
     function varargout = setTargetPeriod(self,varargin)
     %Usage: setTargetPeriod (period)
     %
     %period is of type double. 
-      [varargout{1:nargout}] = yarpMEX(843, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(829, self, varargin{:});
     end
     function varargout = getType(self,varargin)
     %Usage: retval = getType ()
     %
-    %retval is of type Type. 
-      [varargout{1:nargout}] = yarpMEX(844, self, varargin{:});
+    %retval is of type yarp::os::Type. 
+      [varargout{1:nargout}] = yarpMEX(830, self, varargin{:});
     end
     function varargout = promiseType(self,varargin)
     %Usage: promiseType (typ)
     %
-    %typ is of type Type const &. 
-      [varargout{1:nargout}] = yarpMEX(845, self, varargin{:});
+    %typ is of type yarp::os::Type const &. 
+      [varargout{1:nargout}] = yarpMEX(831, self, varargin{:});
     end
     function varargout = setInputMode(self,varargin)
     %Usage: setInputMode (expectInput)
     %
     %expectInput is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(846, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(832, self, varargin{:});
     end
     function varargout = setOutputMode(self,varargin)
     %Usage: setOutputMode (expectOutput)
     %
     %expectOutput is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(847, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(833, self, varargin{:});
     end
     function varargout = setRpcMode(self,varargin)
     %Usage: setRpcMode (expectRpc)
     %
     %expectRpc is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(848, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(834, self, varargin{:});
     end
     function varargout = acquireProperties(self,varargin)
     %Usage: retval = acquireProperties (readOnly)
     %
     %readOnly is of type bool. readOnly is of type bool. retval is of type Property. 
-      [varargout{1:nargout}] = yarpMEX(849, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(835, self, varargin{:});
     end
     function varargout = releaseProperties(self,varargin)
     %Usage: releaseProperties (prop)
     %
     %prop is of type Property. 
-      [varargout{1:nargout}] = yarpMEX(850, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(836, self, varargin{:});
     end
     function varargout = includeNodeInName(self,varargin)
     %Usage: includeNodeInName (flag)
     %
     %flag is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(851, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(837, self, varargin{:});
     end
     function varargout = setCallbackLock(self,varargin)
     %Usage: retval = setCallbackLock (mutex)
     %
     %mutex is of type yarp::os::Mutex *. mutex is of type yarp::os::Mutex *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(852, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(838, self, varargin{:});
     end
     function varargout = removeCallbackLock(self,varargin)
     %Usage: retval = removeCallbackLock ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(853, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(839, self, varargin{:});
     end
     function varargout = lockCallback(self,varargin)
     %Usage: retval = lockCallback ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(854, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(840, self, varargin{:});
     end
     function varargout = tryLockCallback(self,varargin)
     %Usage: retval = tryLockCallback ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(855, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(841, self, varargin{:});
     end
     function varargout = unlockCallback(self,varargin)
     %Usage: unlockCallback ()
     %
-      [varargout{1:nargout}] = yarpMEX(856, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(842, self, varargin{:});
     end
   end
   methods(Static)

--- a/matlab/autogenerated/+yarp/BufferedPortBottle.m
+++ b/matlab/autogenerated/+yarp/BufferedPortBottle.m
@@ -1,4 +1,4 @@
-classdef BufferedPortBottle < SwigRef
+classdef BufferedPortBottle < yarp.Contactable & yarp.TypedReaderBottle & yarp.BottleCallback
     %Usage: BufferedPortBottle ()
     %
   methods
@@ -6,6 +6,9 @@ classdef BufferedPortBottle < SwigRef
       this = yarpMEX(3, self);
     end
     function self = BufferedPortBottle(varargin)
+      self@yarp.Contactable(SwigRef.Null);
+      self@yarp.TypedReaderBottle(SwigRef.Null);
+      self@yarp.BottleCallback(SwigRef.Null);
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;

--- a/matlab/autogenerated/+yarp/BufferedPortImageFloat.m
+++ b/matlab/autogenerated/+yarp/BufferedPortImageFloat.m
@@ -14,14 +14,14 @@ classdef BufferedPortImageFloat < yarp.Contactable & yarp.TypedReaderImageFloat 
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(2433, varargin{:});
+        tmp = yarpMEX(2419, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(2434, self);
+        yarpMEX(2420, self);
         self.SwigClear();
       end
     end
@@ -29,266 +29,266 @@ classdef BufferedPortImageFloat < yarp.Contactable & yarp.TypedReaderImageFloat 
     %Usage: retval = addOutput (contact)
     %
     %contact is of type Contact. contact is of type Contact. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2435, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2421, self, varargin{:});
     end
     function varargout = close(self,varargin)
     %Usage: close ()
     %
-      [varargout{1:nargout}] = yarpMEX(2436, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2422, self, varargin{:});
     end
     function varargout = interrupt(self,varargin)
     %Usage: interrupt ()
     %
-      [varargout{1:nargout}] = yarpMEX(2437, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2423, self, varargin{:});
     end
     function varargout = resume(self,varargin)
     %Usage: resume ()
     %
-      [varargout{1:nargout}] = yarpMEX(2438, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2424, self, varargin{:});
     end
     function varargout = getPendingReads(self,varargin)
     %Usage: retval = getPendingReads ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(2439, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2425, self, varargin{:});
     end
     function varargout = where(self,varargin)
     %Usage: retval = where ()
     %
     %retval is of type Contact. 
-      [varargout{1:nargout}] = yarpMEX(2440, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2426, self, varargin{:});
     end
     function varargout = getName(self,varargin)
     %Usage: retval = getName ()
     %
     %retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(2441, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2427, self, varargin{:});
     end
     function varargout = prepare(self,varargin)
     %Usage: retval = prepare ()
     %
     %retval is of type ImageFloat. 
-      [varargout{1:nargout}] = yarpMEX(2442, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2428, self, varargin{:});
     end
     function varargout = unprepare(self,varargin)
     %Usage: retval = unprepare ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2443, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2429, self, varargin{:});
     end
     function varargout = write(self,varargin)
     %Usage: write ()
     %
-      [varargout{1:nargout}] = yarpMEX(2444, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2430, self, varargin{:});
     end
     function varargout = writeStrict(self,varargin)
     %Usage: writeStrict ()
     %
-      [varargout{1:nargout}] = yarpMEX(2445, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2431, self, varargin{:});
     end
     function varargout = waitForWrite(self,varargin)
     %Usage: waitForWrite ()
     %
-      [varargout{1:nargout}] = yarpMEX(2446, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2432, self, varargin{:});
     end
     function varargout = setStrict(self,varargin)
     %Usage: setStrict ()
     %
-      [varargout{1:nargout}] = yarpMEX(2447, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2433, self, varargin{:});
     end
     function varargout = read(self,varargin)
     %Usage: retval = read ()
     %
     %retval is of type ImageFloat. 
-      [varargout{1:nargout}] = yarpMEX(2448, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2434, self, varargin{:});
     end
     function varargout = lastRead(self,varargin)
     %Usage: retval = lastRead ()
     %
     %retval is of type ImageFloat. 
-      [varargout{1:nargout}] = yarpMEX(2449, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2435, self, varargin{:});
     end
     function varargout = isClosed(self,varargin)
     %Usage: retval = isClosed ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2450, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2436, self, varargin{:});
     end
     function varargout = setReplier(self,varargin)
     %Usage: setReplier (reader)
     %
     %reader is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(2451, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2437, self, varargin{:});
     end
     function varargout = setReader(self,varargin)
     %Usage: setReader (reader)
     %
     %reader is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(2452, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2438, self, varargin{:});
     end
     function varargout = setAdminReader(self,varargin)
     %Usage: setAdminReader (reader)
     %
     %reader is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(2453, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2439, self, varargin{:});
     end
     function varargout = onRead(self,varargin)
     %Usage: onRead (datum)
     %
     %datum is of type ImageFloat. 
-      [varargout{1:nargout}] = yarpMEX(2454, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2440, self, varargin{:});
     end
     function varargout = useCallback(self,varargin)
     %Usage: useCallback ()
     %
-      [varargout{1:nargout}] = yarpMEX(2455, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2441, self, varargin{:});
     end
     function varargout = disableCallback(self,varargin)
     %Usage: disableCallback ()
     %
-      [varargout{1:nargout}] = yarpMEX(2456, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2442, self, varargin{:});
     end
     function varargout = setEnvelope(self,varargin)
     %Usage: retval = setEnvelope (envelope)
     %
     %envelope is of type PortWriter. envelope is of type PortWriter. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2457, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2443, self, varargin{:});
     end
     function varargout = getEnvelope(self,varargin)
     %Usage: retval = getEnvelope (envelope)
     %
     %envelope is of type PortReader. envelope is of type PortReader. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2458, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2444, self, varargin{:});
     end
     function varargout = getInputCount(self,varargin)
     %Usage: retval = getInputCount ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(2459, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2445, self, varargin{:});
     end
     function varargout = getOutputCount(self,varargin)
     %Usage: retval = getOutputCount ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(2460, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2446, self, varargin{:});
     end
     function varargout = isWriting(self,varargin)
     %Usage: retval = isWriting ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2461, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2447, self, varargin{:});
     end
     function varargout = getReport(self,varargin)
     %Usage: getReport (reporter)
     %
     %reporter is of type PortReport. 
-      [varargout{1:nargout}] = yarpMEX(2462, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2448, self, varargin{:});
     end
     function varargout = setReporter(self,varargin)
     %Usage: setReporter (reporter)
     %
     %reporter is of type PortReport. 
-      [varargout{1:nargout}] = yarpMEX(2463, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2449, self, varargin{:});
     end
     function varargout = resetReporter(self,varargin)
     %Usage: resetReporter ()
     %
-      [varargout{1:nargout}] = yarpMEX(2464, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2450, self, varargin{:});
     end
     function varargout = acquire(self,varargin)
     %Usage: retval = acquire ()
     %
     %retval is of type void *. 
-      [varargout{1:nargout}] = yarpMEX(2465, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2451, self, varargin{:});
     end
     function varargout = release(self,varargin)
     %Usage: release (handle)
     %
     %handle is of type void *. 
-      [varargout{1:nargout}] = yarpMEX(2466, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2452, self, varargin{:});
     end
     function varargout = setTargetPeriod(self,varargin)
     %Usage: setTargetPeriod (period)
     %
     %period is of type double. 
-      [varargout{1:nargout}] = yarpMEX(2467, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2453, self, varargin{:});
     end
     function varargout = getType(self,varargin)
     %Usage: retval = getType ()
     %
-    %retval is of type Type. 
-      [varargout{1:nargout}] = yarpMEX(2468, self, varargin{:});
+    %retval is of type yarp::os::Type. 
+      [varargout{1:nargout}] = yarpMEX(2454, self, varargin{:});
     end
     function varargout = promiseType(self,varargin)
     %Usage: promiseType (typ)
     %
-    %typ is of type Type const &. 
-      [varargout{1:nargout}] = yarpMEX(2469, self, varargin{:});
+    %typ is of type yarp::os::Type const &. 
+      [varargout{1:nargout}] = yarpMEX(2455, self, varargin{:});
     end
     function varargout = setInputMode(self,varargin)
     %Usage: setInputMode (expectInput)
     %
     %expectInput is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2470, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2456, self, varargin{:});
     end
     function varargout = setOutputMode(self,varargin)
     %Usage: setOutputMode (expectOutput)
     %
     %expectOutput is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2471, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2457, self, varargin{:});
     end
     function varargout = setRpcMode(self,varargin)
     %Usage: setRpcMode (expectRpc)
     %
     %expectRpc is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2472, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2458, self, varargin{:});
     end
     function varargout = acquireProperties(self,varargin)
     %Usage: retval = acquireProperties (readOnly)
     %
     %readOnly is of type bool. readOnly is of type bool. retval is of type Property. 
-      [varargout{1:nargout}] = yarpMEX(2473, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2459, self, varargin{:});
     end
     function varargout = releaseProperties(self,varargin)
     %Usage: releaseProperties (prop)
     %
     %prop is of type Property. 
-      [varargout{1:nargout}] = yarpMEX(2474, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2460, self, varargin{:});
     end
     function varargout = includeNodeInName(self,varargin)
     %Usage: includeNodeInName (flag)
     %
     %flag is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2475, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2461, self, varargin{:});
     end
     function varargout = setCallbackLock(self,varargin)
     %Usage: retval = setCallbackLock (mutex)
     %
     %mutex is of type yarp::os::Mutex *. mutex is of type yarp::os::Mutex *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2476, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2462, self, varargin{:});
     end
     function varargout = removeCallbackLock(self,varargin)
     %Usage: retval = removeCallbackLock ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2477, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2463, self, varargin{:});
     end
     function varargout = lockCallback(self,varargin)
     %Usage: retval = lockCallback ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2478, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2464, self, varargin{:});
     end
     function varargout = tryLockCallback(self,varargin)
     %Usage: retval = tryLockCallback ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2479, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2465, self, varargin{:});
     end
     function varargout = unlockCallback(self,varargin)
     %Usage: unlockCallback ()
     %
-      [varargout{1:nargout}] = yarpMEX(2480, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2466, self, varargin{:});
     end
   end
   methods(Static)

--- a/matlab/autogenerated/+yarp/BufferedPortImageFloat.m
+++ b/matlab/autogenerated/+yarp/BufferedPortImageFloat.m
@@ -1,4 +1,4 @@
-classdef BufferedPortImageFloat < SwigRef
+classdef BufferedPortImageFloat < yarp.Contactable & yarp.TypedReaderImageFloat & yarp.TypedReaderCallbackImageFloat
     %Usage: BufferedPortImageFloat ()
     %
   methods
@@ -6,6 +6,9 @@ classdef BufferedPortImageFloat < SwigRef
       this = yarpMEX(3, self);
     end
     function self = BufferedPortImageFloat(varargin)
+      self@yarp.Contactable(SwigRef.Null);
+      self@yarp.TypedReaderImageFloat(SwigRef.Null);
+      self@yarp.TypedReaderCallbackImageFloat(SwigRef.Null);
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;

--- a/matlab/autogenerated/+yarp/BufferedPortImageInt.m
+++ b/matlab/autogenerated/+yarp/BufferedPortImageInt.m
@@ -14,14 +14,14 @@ classdef BufferedPortImageInt < yarp.Contactable & yarp.TypedReaderImageInt & ya
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(2229, varargin{:});
+        tmp = yarpMEX(2215, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(2230, self);
+        yarpMEX(2216, self);
         self.SwigClear();
       end
     end
@@ -29,266 +29,266 @@ classdef BufferedPortImageInt < yarp.Contactable & yarp.TypedReaderImageInt & ya
     %Usage: retval = addOutput (contact)
     %
     %contact is of type Contact. contact is of type Contact. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2231, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2217, self, varargin{:});
     end
     function varargout = close(self,varargin)
     %Usage: close ()
     %
-      [varargout{1:nargout}] = yarpMEX(2232, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2218, self, varargin{:});
     end
     function varargout = interrupt(self,varargin)
     %Usage: interrupt ()
     %
-      [varargout{1:nargout}] = yarpMEX(2233, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2219, self, varargin{:});
     end
     function varargout = resume(self,varargin)
     %Usage: resume ()
     %
-      [varargout{1:nargout}] = yarpMEX(2234, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2220, self, varargin{:});
     end
     function varargout = getPendingReads(self,varargin)
     %Usage: retval = getPendingReads ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(2235, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2221, self, varargin{:});
     end
     function varargout = where(self,varargin)
     %Usage: retval = where ()
     %
     %retval is of type Contact. 
-      [varargout{1:nargout}] = yarpMEX(2236, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2222, self, varargin{:});
     end
     function varargout = getName(self,varargin)
     %Usage: retval = getName ()
     %
     %retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(2237, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2223, self, varargin{:});
     end
     function varargout = prepare(self,varargin)
     %Usage: retval = prepare ()
     %
     %retval is of type ImageInt. 
-      [varargout{1:nargout}] = yarpMEX(2238, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2224, self, varargin{:});
     end
     function varargout = unprepare(self,varargin)
     %Usage: retval = unprepare ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2239, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2225, self, varargin{:});
     end
     function varargout = write(self,varargin)
     %Usage: write ()
     %
-      [varargout{1:nargout}] = yarpMEX(2240, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2226, self, varargin{:});
     end
     function varargout = writeStrict(self,varargin)
     %Usage: writeStrict ()
     %
-      [varargout{1:nargout}] = yarpMEX(2241, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2227, self, varargin{:});
     end
     function varargout = waitForWrite(self,varargin)
     %Usage: waitForWrite ()
     %
-      [varargout{1:nargout}] = yarpMEX(2242, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2228, self, varargin{:});
     end
     function varargout = setStrict(self,varargin)
     %Usage: setStrict ()
     %
-      [varargout{1:nargout}] = yarpMEX(2243, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2229, self, varargin{:});
     end
     function varargout = read(self,varargin)
     %Usage: retval = read ()
     %
     %retval is of type ImageInt. 
-      [varargout{1:nargout}] = yarpMEX(2244, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2230, self, varargin{:});
     end
     function varargout = lastRead(self,varargin)
     %Usage: retval = lastRead ()
     %
     %retval is of type ImageInt. 
-      [varargout{1:nargout}] = yarpMEX(2245, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2231, self, varargin{:});
     end
     function varargout = isClosed(self,varargin)
     %Usage: retval = isClosed ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2246, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2232, self, varargin{:});
     end
     function varargout = setReplier(self,varargin)
     %Usage: setReplier (reader)
     %
     %reader is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(2247, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2233, self, varargin{:});
     end
     function varargout = setReader(self,varargin)
     %Usage: setReader (reader)
     %
     %reader is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(2248, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2234, self, varargin{:});
     end
     function varargout = setAdminReader(self,varargin)
     %Usage: setAdminReader (reader)
     %
     %reader is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(2249, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2235, self, varargin{:});
     end
     function varargout = onRead(self,varargin)
     %Usage: onRead (datum)
     %
     %datum is of type ImageInt. 
-      [varargout{1:nargout}] = yarpMEX(2250, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2236, self, varargin{:});
     end
     function varargout = useCallback(self,varargin)
     %Usage: useCallback ()
     %
-      [varargout{1:nargout}] = yarpMEX(2251, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2237, self, varargin{:});
     end
     function varargout = disableCallback(self,varargin)
     %Usage: disableCallback ()
     %
-      [varargout{1:nargout}] = yarpMEX(2252, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2238, self, varargin{:});
     end
     function varargout = setEnvelope(self,varargin)
     %Usage: retval = setEnvelope (envelope)
     %
     %envelope is of type PortWriter. envelope is of type PortWriter. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2253, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2239, self, varargin{:});
     end
     function varargout = getEnvelope(self,varargin)
     %Usage: retval = getEnvelope (envelope)
     %
     %envelope is of type PortReader. envelope is of type PortReader. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2254, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2240, self, varargin{:});
     end
     function varargout = getInputCount(self,varargin)
     %Usage: retval = getInputCount ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(2255, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2241, self, varargin{:});
     end
     function varargout = getOutputCount(self,varargin)
     %Usage: retval = getOutputCount ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(2256, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2242, self, varargin{:});
     end
     function varargout = isWriting(self,varargin)
     %Usage: retval = isWriting ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2257, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2243, self, varargin{:});
     end
     function varargout = getReport(self,varargin)
     %Usage: getReport (reporter)
     %
     %reporter is of type PortReport. 
-      [varargout{1:nargout}] = yarpMEX(2258, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2244, self, varargin{:});
     end
     function varargout = setReporter(self,varargin)
     %Usage: setReporter (reporter)
     %
     %reporter is of type PortReport. 
-      [varargout{1:nargout}] = yarpMEX(2259, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2245, self, varargin{:});
     end
     function varargout = resetReporter(self,varargin)
     %Usage: resetReporter ()
     %
-      [varargout{1:nargout}] = yarpMEX(2260, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2246, self, varargin{:});
     end
     function varargout = acquire(self,varargin)
     %Usage: retval = acquire ()
     %
     %retval is of type void *. 
-      [varargout{1:nargout}] = yarpMEX(2261, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2247, self, varargin{:});
     end
     function varargout = release(self,varargin)
     %Usage: release (handle)
     %
     %handle is of type void *. 
-      [varargout{1:nargout}] = yarpMEX(2262, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2248, self, varargin{:});
     end
     function varargout = setTargetPeriod(self,varargin)
     %Usage: setTargetPeriod (period)
     %
     %period is of type double. 
-      [varargout{1:nargout}] = yarpMEX(2263, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2249, self, varargin{:});
     end
     function varargout = getType(self,varargin)
     %Usage: retval = getType ()
     %
-    %retval is of type Type. 
-      [varargout{1:nargout}] = yarpMEX(2264, self, varargin{:});
+    %retval is of type yarp::os::Type. 
+      [varargout{1:nargout}] = yarpMEX(2250, self, varargin{:});
     end
     function varargout = promiseType(self,varargin)
     %Usage: promiseType (typ)
     %
-    %typ is of type Type const &. 
-      [varargout{1:nargout}] = yarpMEX(2265, self, varargin{:});
+    %typ is of type yarp::os::Type const &. 
+      [varargout{1:nargout}] = yarpMEX(2251, self, varargin{:});
     end
     function varargout = setInputMode(self,varargin)
     %Usage: setInputMode (expectInput)
     %
     %expectInput is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2266, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2252, self, varargin{:});
     end
     function varargout = setOutputMode(self,varargin)
     %Usage: setOutputMode (expectOutput)
     %
     %expectOutput is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2267, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2253, self, varargin{:});
     end
     function varargout = setRpcMode(self,varargin)
     %Usage: setRpcMode (expectRpc)
     %
     %expectRpc is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2268, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2254, self, varargin{:});
     end
     function varargout = acquireProperties(self,varargin)
     %Usage: retval = acquireProperties (readOnly)
     %
     %readOnly is of type bool. readOnly is of type bool. retval is of type Property. 
-      [varargout{1:nargout}] = yarpMEX(2269, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2255, self, varargin{:});
     end
     function varargout = releaseProperties(self,varargin)
     %Usage: releaseProperties (prop)
     %
     %prop is of type Property. 
-      [varargout{1:nargout}] = yarpMEX(2270, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2256, self, varargin{:});
     end
     function varargout = includeNodeInName(self,varargin)
     %Usage: includeNodeInName (flag)
     %
     %flag is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2271, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2257, self, varargin{:});
     end
     function varargout = setCallbackLock(self,varargin)
     %Usage: retval = setCallbackLock (mutex)
     %
     %mutex is of type yarp::os::Mutex *. mutex is of type yarp::os::Mutex *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2272, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2258, self, varargin{:});
     end
     function varargout = removeCallbackLock(self,varargin)
     %Usage: retval = removeCallbackLock ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2273, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2259, self, varargin{:});
     end
     function varargout = lockCallback(self,varargin)
     %Usage: retval = lockCallback ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2274, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2260, self, varargin{:});
     end
     function varargout = tryLockCallback(self,varargin)
     %Usage: retval = tryLockCallback ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2275, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2261, self, varargin{:});
     end
     function varargout = unlockCallback(self,varargin)
     %Usage: unlockCallback ()
     %
-      [varargout{1:nargout}] = yarpMEX(2276, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2262, self, varargin{:});
     end
   end
   methods(Static)

--- a/matlab/autogenerated/+yarp/BufferedPortImageInt.m
+++ b/matlab/autogenerated/+yarp/BufferedPortImageInt.m
@@ -1,4 +1,4 @@
-classdef BufferedPortImageInt < SwigRef
+classdef BufferedPortImageInt < yarp.Contactable & yarp.TypedReaderImageInt & yarp.TypedReaderCallbackImageInt
     %Usage: BufferedPortImageInt ()
     %
   methods
@@ -6,6 +6,9 @@ classdef BufferedPortImageInt < SwigRef
       this = yarpMEX(3, self);
     end
     function self = BufferedPortImageInt(varargin)
+      self@yarp.Contactable(SwigRef.Null);
+      self@yarp.TypedReaderImageInt(SwigRef.Null);
+      self@yarp.TypedReaderCallbackImageInt(SwigRef.Null);
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;

--- a/matlab/autogenerated/+yarp/BufferedPortImageMono.m
+++ b/matlab/autogenerated/+yarp/BufferedPortImageMono.m
@@ -1,4 +1,4 @@
-classdef BufferedPortImageMono < SwigRef
+classdef BufferedPortImageMono < yarp.Contactable & yarp.TypedReaderImageMono & yarp.TypedReaderCallbackImageMono
     %Usage: BufferedPortImageMono ()
     %
   methods
@@ -6,6 +6,9 @@ classdef BufferedPortImageMono < SwigRef
       this = yarpMEX(3, self);
     end
     function self = BufferedPortImageMono(varargin)
+      self@yarp.Contactable(SwigRef.Null);
+      self@yarp.TypedReaderImageMono(SwigRef.Null);
+      self@yarp.TypedReaderCallbackImageMono(SwigRef.Null);
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;

--- a/matlab/autogenerated/+yarp/BufferedPortImageMono.m
+++ b/matlab/autogenerated/+yarp/BufferedPortImageMono.m
@@ -14,14 +14,14 @@ classdef BufferedPortImageMono < yarp.Contactable & yarp.TypedReaderImageMono & 
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(2083, varargin{:});
+        tmp = yarpMEX(2069, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(2084, self);
+        yarpMEX(2070, self);
         self.SwigClear();
       end
     end
@@ -29,266 +29,266 @@ classdef BufferedPortImageMono < yarp.Contactable & yarp.TypedReaderImageMono & 
     %Usage: retval = addOutput (contact)
     %
     %contact is of type Contact. contact is of type Contact. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2085, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2071, self, varargin{:});
     end
     function varargout = close(self,varargin)
     %Usage: close ()
     %
-      [varargout{1:nargout}] = yarpMEX(2086, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2072, self, varargin{:});
     end
     function varargout = interrupt(self,varargin)
     %Usage: interrupt ()
     %
-      [varargout{1:nargout}] = yarpMEX(2087, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2073, self, varargin{:});
     end
     function varargout = resume(self,varargin)
     %Usage: resume ()
     %
-      [varargout{1:nargout}] = yarpMEX(2088, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2074, self, varargin{:});
     end
     function varargout = getPendingReads(self,varargin)
     %Usage: retval = getPendingReads ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(2089, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2075, self, varargin{:});
     end
     function varargout = where(self,varargin)
     %Usage: retval = where ()
     %
     %retval is of type Contact. 
-      [varargout{1:nargout}] = yarpMEX(2090, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2076, self, varargin{:});
     end
     function varargout = getName(self,varargin)
     %Usage: retval = getName ()
     %
     %retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(2091, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2077, self, varargin{:});
     end
     function varargout = prepare(self,varargin)
     %Usage: retval = prepare ()
     %
     %retval is of type ImageMono. 
-      [varargout{1:nargout}] = yarpMEX(2092, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2078, self, varargin{:});
     end
     function varargout = unprepare(self,varargin)
     %Usage: retval = unprepare ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2093, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2079, self, varargin{:});
     end
     function varargout = write(self,varargin)
     %Usage: write ()
     %
-      [varargout{1:nargout}] = yarpMEX(2094, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2080, self, varargin{:});
     end
     function varargout = writeStrict(self,varargin)
     %Usage: writeStrict ()
     %
-      [varargout{1:nargout}] = yarpMEX(2095, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2081, self, varargin{:});
     end
     function varargout = waitForWrite(self,varargin)
     %Usage: waitForWrite ()
     %
-      [varargout{1:nargout}] = yarpMEX(2096, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2082, self, varargin{:});
     end
     function varargout = setStrict(self,varargin)
     %Usage: setStrict ()
     %
-      [varargout{1:nargout}] = yarpMEX(2097, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2083, self, varargin{:});
     end
     function varargout = read(self,varargin)
     %Usage: retval = read ()
     %
     %retval is of type ImageMono. 
-      [varargout{1:nargout}] = yarpMEX(2098, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2084, self, varargin{:});
     end
     function varargout = lastRead(self,varargin)
     %Usage: retval = lastRead ()
     %
     %retval is of type ImageMono. 
-      [varargout{1:nargout}] = yarpMEX(2099, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2085, self, varargin{:});
     end
     function varargout = isClosed(self,varargin)
     %Usage: retval = isClosed ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2100, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2086, self, varargin{:});
     end
     function varargout = setReplier(self,varargin)
     %Usage: setReplier (reader)
     %
     %reader is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(2101, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2087, self, varargin{:});
     end
     function varargout = setReader(self,varargin)
     %Usage: setReader (reader)
     %
     %reader is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(2102, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2088, self, varargin{:});
     end
     function varargout = setAdminReader(self,varargin)
     %Usage: setAdminReader (reader)
     %
     %reader is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(2103, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2089, self, varargin{:});
     end
     function varargout = onRead(self,varargin)
     %Usage: onRead (datum)
     %
     %datum is of type ImageMono. 
-      [varargout{1:nargout}] = yarpMEX(2104, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2090, self, varargin{:});
     end
     function varargout = useCallback(self,varargin)
     %Usage: useCallback ()
     %
-      [varargout{1:nargout}] = yarpMEX(2105, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2091, self, varargin{:});
     end
     function varargout = disableCallback(self,varargin)
     %Usage: disableCallback ()
     %
-      [varargout{1:nargout}] = yarpMEX(2106, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2092, self, varargin{:});
     end
     function varargout = setEnvelope(self,varargin)
     %Usage: retval = setEnvelope (envelope)
     %
     %envelope is of type PortWriter. envelope is of type PortWriter. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2107, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2093, self, varargin{:});
     end
     function varargout = getEnvelope(self,varargin)
     %Usage: retval = getEnvelope (envelope)
     %
     %envelope is of type PortReader. envelope is of type PortReader. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2108, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2094, self, varargin{:});
     end
     function varargout = getInputCount(self,varargin)
     %Usage: retval = getInputCount ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(2109, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2095, self, varargin{:});
     end
     function varargout = getOutputCount(self,varargin)
     %Usage: retval = getOutputCount ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(2110, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2096, self, varargin{:});
     end
     function varargout = isWriting(self,varargin)
     %Usage: retval = isWriting ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2111, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2097, self, varargin{:});
     end
     function varargout = getReport(self,varargin)
     %Usage: getReport (reporter)
     %
     %reporter is of type PortReport. 
-      [varargout{1:nargout}] = yarpMEX(2112, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2098, self, varargin{:});
     end
     function varargout = setReporter(self,varargin)
     %Usage: setReporter (reporter)
     %
     %reporter is of type PortReport. 
-      [varargout{1:nargout}] = yarpMEX(2113, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2099, self, varargin{:});
     end
     function varargout = resetReporter(self,varargin)
     %Usage: resetReporter ()
     %
-      [varargout{1:nargout}] = yarpMEX(2114, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2100, self, varargin{:});
     end
     function varargout = acquire(self,varargin)
     %Usage: retval = acquire ()
     %
     %retval is of type void *. 
-      [varargout{1:nargout}] = yarpMEX(2115, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2101, self, varargin{:});
     end
     function varargout = release(self,varargin)
     %Usage: release (handle)
     %
     %handle is of type void *. 
-      [varargout{1:nargout}] = yarpMEX(2116, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2102, self, varargin{:});
     end
     function varargout = setTargetPeriod(self,varargin)
     %Usage: setTargetPeriod (period)
     %
     %period is of type double. 
-      [varargout{1:nargout}] = yarpMEX(2117, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2103, self, varargin{:});
     end
     function varargout = getType(self,varargin)
     %Usage: retval = getType ()
     %
-    %retval is of type Type. 
-      [varargout{1:nargout}] = yarpMEX(2118, self, varargin{:});
+    %retval is of type yarp::os::Type. 
+      [varargout{1:nargout}] = yarpMEX(2104, self, varargin{:});
     end
     function varargout = promiseType(self,varargin)
     %Usage: promiseType (typ)
     %
-    %typ is of type Type const &. 
-      [varargout{1:nargout}] = yarpMEX(2119, self, varargin{:});
+    %typ is of type yarp::os::Type const &. 
+      [varargout{1:nargout}] = yarpMEX(2105, self, varargin{:});
     end
     function varargout = setInputMode(self,varargin)
     %Usage: setInputMode (expectInput)
     %
     %expectInput is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2120, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2106, self, varargin{:});
     end
     function varargout = setOutputMode(self,varargin)
     %Usage: setOutputMode (expectOutput)
     %
     %expectOutput is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2121, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2107, self, varargin{:});
     end
     function varargout = setRpcMode(self,varargin)
     %Usage: setRpcMode (expectRpc)
     %
     %expectRpc is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2122, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2108, self, varargin{:});
     end
     function varargout = acquireProperties(self,varargin)
     %Usage: retval = acquireProperties (readOnly)
     %
     %readOnly is of type bool. readOnly is of type bool. retval is of type Property. 
-      [varargout{1:nargout}] = yarpMEX(2123, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2109, self, varargin{:});
     end
     function varargout = releaseProperties(self,varargin)
     %Usage: releaseProperties (prop)
     %
     %prop is of type Property. 
-      [varargout{1:nargout}] = yarpMEX(2124, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2110, self, varargin{:});
     end
     function varargout = includeNodeInName(self,varargin)
     %Usage: includeNodeInName (flag)
     %
     %flag is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2125, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2111, self, varargin{:});
     end
     function varargout = setCallbackLock(self,varargin)
     %Usage: retval = setCallbackLock (mutex)
     %
     %mutex is of type yarp::os::Mutex *. mutex is of type yarp::os::Mutex *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2126, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2112, self, varargin{:});
     end
     function varargout = removeCallbackLock(self,varargin)
     %Usage: retval = removeCallbackLock ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2127, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2113, self, varargin{:});
     end
     function varargout = lockCallback(self,varargin)
     %Usage: retval = lockCallback ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2128, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2114, self, varargin{:});
     end
     function varargout = tryLockCallback(self,varargin)
     %Usage: retval = tryLockCallback ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2129, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2115, self, varargin{:});
     end
     function varargout = unlockCallback(self,varargin)
     %Usage: unlockCallback ()
     %
-      [varargout{1:nargout}] = yarpMEX(2130, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2116, self, varargin{:});
     end
   end
   methods(Static)

--- a/matlab/autogenerated/+yarp/BufferedPortImageMono16.m
+++ b/matlab/autogenerated/+yarp/BufferedPortImageMono16.m
@@ -14,14 +14,14 @@ classdef BufferedPortImageMono16 < yarp.Contactable & yarp.TypedReaderImageMono1
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(2155, varargin{:});
+        tmp = yarpMEX(2141, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(2156, self);
+        yarpMEX(2142, self);
         self.SwigClear();
       end
     end
@@ -29,266 +29,266 @@ classdef BufferedPortImageMono16 < yarp.Contactable & yarp.TypedReaderImageMono1
     %Usage: retval = addOutput (contact)
     %
     %contact is of type Contact. contact is of type Contact. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2157, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2143, self, varargin{:});
     end
     function varargout = close(self,varargin)
     %Usage: close ()
     %
-      [varargout{1:nargout}] = yarpMEX(2158, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2144, self, varargin{:});
     end
     function varargout = interrupt(self,varargin)
     %Usage: interrupt ()
     %
-      [varargout{1:nargout}] = yarpMEX(2159, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2145, self, varargin{:});
     end
     function varargout = resume(self,varargin)
     %Usage: resume ()
     %
-      [varargout{1:nargout}] = yarpMEX(2160, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2146, self, varargin{:});
     end
     function varargout = getPendingReads(self,varargin)
     %Usage: retval = getPendingReads ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(2161, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2147, self, varargin{:});
     end
     function varargout = where(self,varargin)
     %Usage: retval = where ()
     %
     %retval is of type Contact. 
-      [varargout{1:nargout}] = yarpMEX(2162, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2148, self, varargin{:});
     end
     function varargout = getName(self,varargin)
     %Usage: retval = getName ()
     %
     %retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(2163, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2149, self, varargin{:});
     end
     function varargout = prepare(self,varargin)
     %Usage: retval = prepare ()
     %
     %retval is of type ImageMono16. 
-      [varargout{1:nargout}] = yarpMEX(2164, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2150, self, varargin{:});
     end
     function varargout = unprepare(self,varargin)
     %Usage: retval = unprepare ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2165, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2151, self, varargin{:});
     end
     function varargout = write(self,varargin)
     %Usage: write ()
     %
-      [varargout{1:nargout}] = yarpMEX(2166, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2152, self, varargin{:});
     end
     function varargout = writeStrict(self,varargin)
     %Usage: writeStrict ()
     %
-      [varargout{1:nargout}] = yarpMEX(2167, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2153, self, varargin{:});
     end
     function varargout = waitForWrite(self,varargin)
     %Usage: waitForWrite ()
     %
-      [varargout{1:nargout}] = yarpMEX(2168, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2154, self, varargin{:});
     end
     function varargout = setStrict(self,varargin)
     %Usage: setStrict ()
     %
-      [varargout{1:nargout}] = yarpMEX(2169, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2155, self, varargin{:});
     end
     function varargout = read(self,varargin)
     %Usage: retval = read ()
     %
     %retval is of type ImageMono16. 
-      [varargout{1:nargout}] = yarpMEX(2170, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2156, self, varargin{:});
     end
     function varargout = lastRead(self,varargin)
     %Usage: retval = lastRead ()
     %
     %retval is of type ImageMono16. 
-      [varargout{1:nargout}] = yarpMEX(2171, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2157, self, varargin{:});
     end
     function varargout = isClosed(self,varargin)
     %Usage: retval = isClosed ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2172, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2158, self, varargin{:});
     end
     function varargout = setReplier(self,varargin)
     %Usage: setReplier (reader)
     %
     %reader is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(2173, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2159, self, varargin{:});
     end
     function varargout = setReader(self,varargin)
     %Usage: setReader (reader)
     %
     %reader is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(2174, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2160, self, varargin{:});
     end
     function varargout = setAdminReader(self,varargin)
     %Usage: setAdminReader (reader)
     %
     %reader is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(2175, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2161, self, varargin{:});
     end
     function varargout = onRead(self,varargin)
     %Usage: onRead (datum)
     %
     %datum is of type ImageMono16. 
-      [varargout{1:nargout}] = yarpMEX(2176, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2162, self, varargin{:});
     end
     function varargout = useCallback(self,varargin)
     %Usage: useCallback ()
     %
-      [varargout{1:nargout}] = yarpMEX(2177, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2163, self, varargin{:});
     end
     function varargout = disableCallback(self,varargin)
     %Usage: disableCallback ()
     %
-      [varargout{1:nargout}] = yarpMEX(2178, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2164, self, varargin{:});
     end
     function varargout = setEnvelope(self,varargin)
     %Usage: retval = setEnvelope (envelope)
     %
     %envelope is of type PortWriter. envelope is of type PortWriter. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2179, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2165, self, varargin{:});
     end
     function varargout = getEnvelope(self,varargin)
     %Usage: retval = getEnvelope (envelope)
     %
     %envelope is of type PortReader. envelope is of type PortReader. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2180, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2166, self, varargin{:});
     end
     function varargout = getInputCount(self,varargin)
     %Usage: retval = getInputCount ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(2181, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2167, self, varargin{:});
     end
     function varargout = getOutputCount(self,varargin)
     %Usage: retval = getOutputCount ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(2182, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2168, self, varargin{:});
     end
     function varargout = isWriting(self,varargin)
     %Usage: retval = isWriting ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2183, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2169, self, varargin{:});
     end
     function varargout = getReport(self,varargin)
     %Usage: getReport (reporter)
     %
     %reporter is of type PortReport. 
-      [varargout{1:nargout}] = yarpMEX(2184, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2170, self, varargin{:});
     end
     function varargout = setReporter(self,varargin)
     %Usage: setReporter (reporter)
     %
     %reporter is of type PortReport. 
-      [varargout{1:nargout}] = yarpMEX(2185, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2171, self, varargin{:});
     end
     function varargout = resetReporter(self,varargin)
     %Usage: resetReporter ()
     %
-      [varargout{1:nargout}] = yarpMEX(2186, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2172, self, varargin{:});
     end
     function varargout = acquire(self,varargin)
     %Usage: retval = acquire ()
     %
     %retval is of type void *. 
-      [varargout{1:nargout}] = yarpMEX(2187, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2173, self, varargin{:});
     end
     function varargout = release(self,varargin)
     %Usage: release (handle)
     %
     %handle is of type void *. 
-      [varargout{1:nargout}] = yarpMEX(2188, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2174, self, varargin{:});
     end
     function varargout = setTargetPeriod(self,varargin)
     %Usage: setTargetPeriod (period)
     %
     %period is of type double. 
-      [varargout{1:nargout}] = yarpMEX(2189, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2175, self, varargin{:});
     end
     function varargout = getType(self,varargin)
     %Usage: retval = getType ()
     %
-    %retval is of type Type. 
-      [varargout{1:nargout}] = yarpMEX(2190, self, varargin{:});
+    %retval is of type yarp::os::Type. 
+      [varargout{1:nargout}] = yarpMEX(2176, self, varargin{:});
     end
     function varargout = promiseType(self,varargin)
     %Usage: promiseType (typ)
     %
-    %typ is of type Type const &. 
-      [varargout{1:nargout}] = yarpMEX(2191, self, varargin{:});
+    %typ is of type yarp::os::Type const &. 
+      [varargout{1:nargout}] = yarpMEX(2177, self, varargin{:});
     end
     function varargout = setInputMode(self,varargin)
     %Usage: setInputMode (expectInput)
     %
     %expectInput is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2192, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2178, self, varargin{:});
     end
     function varargout = setOutputMode(self,varargin)
     %Usage: setOutputMode (expectOutput)
     %
     %expectOutput is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2193, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2179, self, varargin{:});
     end
     function varargout = setRpcMode(self,varargin)
     %Usage: setRpcMode (expectRpc)
     %
     %expectRpc is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2194, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2180, self, varargin{:});
     end
     function varargout = acquireProperties(self,varargin)
     %Usage: retval = acquireProperties (readOnly)
     %
     %readOnly is of type bool. readOnly is of type bool. retval is of type Property. 
-      [varargout{1:nargout}] = yarpMEX(2195, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2181, self, varargin{:});
     end
     function varargout = releaseProperties(self,varargin)
     %Usage: releaseProperties (prop)
     %
     %prop is of type Property. 
-      [varargout{1:nargout}] = yarpMEX(2196, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2182, self, varargin{:});
     end
     function varargout = includeNodeInName(self,varargin)
     %Usage: includeNodeInName (flag)
     %
     %flag is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2197, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2183, self, varargin{:});
     end
     function varargout = setCallbackLock(self,varargin)
     %Usage: retval = setCallbackLock (mutex)
     %
     %mutex is of type yarp::os::Mutex *. mutex is of type yarp::os::Mutex *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2198, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2184, self, varargin{:});
     end
     function varargout = removeCallbackLock(self,varargin)
     %Usage: retval = removeCallbackLock ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2199, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2185, self, varargin{:});
     end
     function varargout = lockCallback(self,varargin)
     %Usage: retval = lockCallback ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2200, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2186, self, varargin{:});
     end
     function varargout = tryLockCallback(self,varargin)
     %Usage: retval = tryLockCallback ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2201, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2187, self, varargin{:});
     end
     function varargout = unlockCallback(self,varargin)
     %Usage: unlockCallback ()
     %
-      [varargout{1:nargout}] = yarpMEX(2202, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2188, self, varargin{:});
     end
   end
   methods(Static)

--- a/matlab/autogenerated/+yarp/BufferedPortImageMono16.m
+++ b/matlab/autogenerated/+yarp/BufferedPortImageMono16.m
@@ -1,4 +1,4 @@
-classdef BufferedPortImageMono16 < SwigRef
+classdef BufferedPortImageMono16 < yarp.Contactable & yarp.TypedReaderImageMono16 & yarp.TypedReaderCallbackImageMono16
     %Usage: BufferedPortImageMono16 ()
     %
   methods
@@ -6,6 +6,9 @@ classdef BufferedPortImageMono16 < SwigRef
       this = yarpMEX(3, self);
     end
     function self = BufferedPortImageMono16(varargin)
+      self@yarp.Contactable(SwigRef.Null);
+      self@yarp.TypedReaderImageMono16(SwigRef.Null);
+      self@yarp.TypedReaderCallbackImageMono16(SwigRef.Null);
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;

--- a/matlab/autogenerated/+yarp/BufferedPortImageRgb.m
+++ b/matlab/autogenerated/+yarp/BufferedPortImageRgb.m
@@ -1,4 +1,4 @@
-classdef BufferedPortImageRgb < SwigRef
+classdef BufferedPortImageRgb < yarp.Contactable & yarp.TypedReaderImageRgb & yarp.TypedReaderCallbackImageRgb
     %Usage: BufferedPortImageRgb ()
     %
   methods
@@ -6,6 +6,9 @@ classdef BufferedPortImageRgb < SwigRef
       this = yarpMEX(3, self);
     end
     function self = BufferedPortImageRgb(varargin)
+      self@yarp.Contactable(SwigRef.Null);
+      self@yarp.TypedReaderImageRgb(SwigRef.Null);
+      self@yarp.TypedReaderCallbackImageRgb(SwigRef.Null);
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;

--- a/matlab/autogenerated/+yarp/BufferedPortImageRgb.m
+++ b/matlab/autogenerated/+yarp/BufferedPortImageRgb.m
@@ -14,14 +14,14 @@ classdef BufferedPortImageRgb < yarp.Contactable & yarp.TypedReaderImageRgb & ya
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(1939, varargin{:});
+        tmp = yarpMEX(1925, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1940, self);
+        yarpMEX(1926, self);
         self.SwigClear();
       end
     end
@@ -29,266 +29,266 @@ classdef BufferedPortImageRgb < yarp.Contactable & yarp.TypedReaderImageRgb & ya
     %Usage: retval = addOutput (contact)
     %
     %contact is of type Contact. contact is of type Contact. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1941, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1927, self, varargin{:});
     end
     function varargout = close(self,varargin)
     %Usage: close ()
     %
-      [varargout{1:nargout}] = yarpMEX(1942, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1928, self, varargin{:});
     end
     function varargout = interrupt(self,varargin)
     %Usage: interrupt ()
     %
-      [varargout{1:nargout}] = yarpMEX(1943, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1929, self, varargin{:});
     end
     function varargout = resume(self,varargin)
     %Usage: resume ()
     %
-      [varargout{1:nargout}] = yarpMEX(1944, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1930, self, varargin{:});
     end
     function varargout = getPendingReads(self,varargin)
     %Usage: retval = getPendingReads ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(1945, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1931, self, varargin{:});
     end
     function varargout = where(self,varargin)
     %Usage: retval = where ()
     %
     %retval is of type Contact. 
-      [varargout{1:nargout}] = yarpMEX(1946, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1932, self, varargin{:});
     end
     function varargout = getName(self,varargin)
     %Usage: retval = getName ()
     %
     %retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(1947, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1933, self, varargin{:});
     end
     function varargout = prepare(self,varargin)
     %Usage: retval = prepare ()
     %
     %retval is of type ImageRgb. 
-      [varargout{1:nargout}] = yarpMEX(1948, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1934, self, varargin{:});
     end
     function varargout = unprepare(self,varargin)
     %Usage: retval = unprepare ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1949, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1935, self, varargin{:});
     end
     function varargout = write(self,varargin)
     %Usage: write ()
     %
-      [varargout{1:nargout}] = yarpMEX(1950, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1936, self, varargin{:});
     end
     function varargout = writeStrict(self,varargin)
     %Usage: writeStrict ()
     %
-      [varargout{1:nargout}] = yarpMEX(1951, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1937, self, varargin{:});
     end
     function varargout = waitForWrite(self,varargin)
     %Usage: waitForWrite ()
     %
-      [varargout{1:nargout}] = yarpMEX(1952, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1938, self, varargin{:});
     end
     function varargout = setStrict(self,varargin)
     %Usage: setStrict ()
     %
-      [varargout{1:nargout}] = yarpMEX(1953, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1939, self, varargin{:});
     end
     function varargout = read(self,varargin)
     %Usage: retval = read ()
     %
     %retval is of type ImageRgb. 
-      [varargout{1:nargout}] = yarpMEX(1954, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1940, self, varargin{:});
     end
     function varargout = lastRead(self,varargin)
     %Usage: retval = lastRead ()
     %
     %retval is of type ImageRgb. 
-      [varargout{1:nargout}] = yarpMEX(1955, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1941, self, varargin{:});
     end
     function varargout = isClosed(self,varargin)
     %Usage: retval = isClosed ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1956, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1942, self, varargin{:});
     end
     function varargout = setReplier(self,varargin)
     %Usage: setReplier (reader)
     %
     %reader is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(1957, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1943, self, varargin{:});
     end
     function varargout = setReader(self,varargin)
     %Usage: setReader (reader)
     %
     %reader is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(1958, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1944, self, varargin{:});
     end
     function varargout = setAdminReader(self,varargin)
     %Usage: setAdminReader (reader)
     %
     %reader is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(1959, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1945, self, varargin{:});
     end
     function varargout = onRead(self,varargin)
     %Usage: onRead (datum)
     %
     %datum is of type ImageRgb. 
-      [varargout{1:nargout}] = yarpMEX(1960, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1946, self, varargin{:});
     end
     function varargout = useCallback(self,varargin)
     %Usage: useCallback ()
     %
-      [varargout{1:nargout}] = yarpMEX(1961, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1947, self, varargin{:});
     end
     function varargout = disableCallback(self,varargin)
     %Usage: disableCallback ()
     %
-      [varargout{1:nargout}] = yarpMEX(1962, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1948, self, varargin{:});
     end
     function varargout = setEnvelope(self,varargin)
     %Usage: retval = setEnvelope (envelope)
     %
     %envelope is of type PortWriter. envelope is of type PortWriter. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1963, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1949, self, varargin{:});
     end
     function varargout = getEnvelope(self,varargin)
     %Usage: retval = getEnvelope (envelope)
     %
     %envelope is of type PortReader. envelope is of type PortReader. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1964, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1950, self, varargin{:});
     end
     function varargout = getInputCount(self,varargin)
     %Usage: retval = getInputCount ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(1965, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1951, self, varargin{:});
     end
     function varargout = getOutputCount(self,varargin)
     %Usage: retval = getOutputCount ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(1966, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1952, self, varargin{:});
     end
     function varargout = isWriting(self,varargin)
     %Usage: retval = isWriting ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1967, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1953, self, varargin{:});
     end
     function varargout = getReport(self,varargin)
     %Usage: getReport (reporter)
     %
     %reporter is of type PortReport. 
-      [varargout{1:nargout}] = yarpMEX(1968, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1954, self, varargin{:});
     end
     function varargout = setReporter(self,varargin)
     %Usage: setReporter (reporter)
     %
     %reporter is of type PortReport. 
-      [varargout{1:nargout}] = yarpMEX(1969, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1955, self, varargin{:});
     end
     function varargout = resetReporter(self,varargin)
     %Usage: resetReporter ()
     %
-      [varargout{1:nargout}] = yarpMEX(1970, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1956, self, varargin{:});
     end
     function varargout = acquire(self,varargin)
     %Usage: retval = acquire ()
     %
     %retval is of type void *. 
-      [varargout{1:nargout}] = yarpMEX(1971, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1957, self, varargin{:});
     end
     function varargout = release(self,varargin)
     %Usage: release (handle)
     %
     %handle is of type void *. 
-      [varargout{1:nargout}] = yarpMEX(1972, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1958, self, varargin{:});
     end
     function varargout = setTargetPeriod(self,varargin)
     %Usage: setTargetPeriod (period)
     %
     %period is of type double. 
-      [varargout{1:nargout}] = yarpMEX(1973, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1959, self, varargin{:});
     end
     function varargout = getType(self,varargin)
     %Usage: retval = getType ()
     %
-    %retval is of type Type. 
-      [varargout{1:nargout}] = yarpMEX(1974, self, varargin{:});
+    %retval is of type yarp::os::Type. 
+      [varargout{1:nargout}] = yarpMEX(1960, self, varargin{:});
     end
     function varargout = promiseType(self,varargin)
     %Usage: promiseType (typ)
     %
-    %typ is of type Type const &. 
-      [varargout{1:nargout}] = yarpMEX(1975, self, varargin{:});
+    %typ is of type yarp::os::Type const &. 
+      [varargout{1:nargout}] = yarpMEX(1961, self, varargin{:});
     end
     function varargout = setInputMode(self,varargin)
     %Usage: setInputMode (expectInput)
     %
     %expectInput is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1976, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1962, self, varargin{:});
     end
     function varargout = setOutputMode(self,varargin)
     %Usage: setOutputMode (expectOutput)
     %
     %expectOutput is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1977, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1963, self, varargin{:});
     end
     function varargout = setRpcMode(self,varargin)
     %Usage: setRpcMode (expectRpc)
     %
     %expectRpc is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1978, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1964, self, varargin{:});
     end
     function varargout = acquireProperties(self,varargin)
     %Usage: retval = acquireProperties (readOnly)
     %
     %readOnly is of type bool. readOnly is of type bool. retval is of type Property. 
-      [varargout{1:nargout}] = yarpMEX(1979, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1965, self, varargin{:});
     end
     function varargout = releaseProperties(self,varargin)
     %Usage: releaseProperties (prop)
     %
     %prop is of type Property. 
-      [varargout{1:nargout}] = yarpMEX(1980, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1966, self, varargin{:});
     end
     function varargout = includeNodeInName(self,varargin)
     %Usage: includeNodeInName (flag)
     %
     %flag is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1981, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1967, self, varargin{:});
     end
     function varargout = setCallbackLock(self,varargin)
     %Usage: retval = setCallbackLock (mutex)
     %
     %mutex is of type yarp::os::Mutex *. mutex is of type yarp::os::Mutex *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1982, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1968, self, varargin{:});
     end
     function varargout = removeCallbackLock(self,varargin)
     %Usage: retval = removeCallbackLock ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1983, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1969, self, varargin{:});
     end
     function varargout = lockCallback(self,varargin)
     %Usage: retval = lockCallback ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1984, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1970, self, varargin{:});
     end
     function varargout = tryLockCallback(self,varargin)
     %Usage: retval = tryLockCallback ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1985, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1971, self, varargin{:});
     end
     function varargout = unlockCallback(self,varargin)
     %Usage: unlockCallback ()
     %
-      [varargout{1:nargout}] = yarpMEX(1986, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1972, self, varargin{:});
     end
   end
   methods(Static)

--- a/matlab/autogenerated/+yarp/BufferedPortImageRgbFloat.m
+++ b/matlab/autogenerated/+yarp/BufferedPortImageRgbFloat.m
@@ -14,14 +14,14 @@ classdef BufferedPortImageRgbFloat < yarp.Contactable & yarp.TypedReaderImageRgb
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(2505, varargin{:});
+        tmp = yarpMEX(2491, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(2506, self);
+        yarpMEX(2492, self);
         self.SwigClear();
       end
     end
@@ -29,266 +29,266 @@ classdef BufferedPortImageRgbFloat < yarp.Contactable & yarp.TypedReaderImageRgb
     %Usage: retval = addOutput (contact)
     %
     %contact is of type Contact. contact is of type Contact. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2507, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2493, self, varargin{:});
     end
     function varargout = close(self,varargin)
     %Usage: close ()
     %
-      [varargout{1:nargout}] = yarpMEX(2508, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2494, self, varargin{:});
     end
     function varargout = interrupt(self,varargin)
     %Usage: interrupt ()
     %
-      [varargout{1:nargout}] = yarpMEX(2509, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2495, self, varargin{:});
     end
     function varargout = resume(self,varargin)
     %Usage: resume ()
     %
-      [varargout{1:nargout}] = yarpMEX(2510, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2496, self, varargin{:});
     end
     function varargout = getPendingReads(self,varargin)
     %Usage: retval = getPendingReads ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(2511, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2497, self, varargin{:});
     end
     function varargout = where(self,varargin)
     %Usage: retval = where ()
     %
     %retval is of type Contact. 
-      [varargout{1:nargout}] = yarpMEX(2512, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2498, self, varargin{:});
     end
     function varargout = getName(self,varargin)
     %Usage: retval = getName ()
     %
     %retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(2513, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2499, self, varargin{:});
     end
     function varargout = prepare(self,varargin)
     %Usage: retval = prepare ()
     %
     %retval is of type ImageRgbFloat. 
-      [varargout{1:nargout}] = yarpMEX(2514, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2500, self, varargin{:});
     end
     function varargout = unprepare(self,varargin)
     %Usage: retval = unprepare ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2515, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2501, self, varargin{:});
     end
     function varargout = write(self,varargin)
     %Usage: write ()
     %
-      [varargout{1:nargout}] = yarpMEX(2516, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2502, self, varargin{:});
     end
     function varargout = writeStrict(self,varargin)
     %Usage: writeStrict ()
     %
-      [varargout{1:nargout}] = yarpMEX(2517, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2503, self, varargin{:});
     end
     function varargout = waitForWrite(self,varargin)
     %Usage: waitForWrite ()
     %
-      [varargout{1:nargout}] = yarpMEX(2518, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2504, self, varargin{:});
     end
     function varargout = setStrict(self,varargin)
     %Usage: setStrict ()
     %
-      [varargout{1:nargout}] = yarpMEX(2519, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2505, self, varargin{:});
     end
     function varargout = read(self,varargin)
     %Usage: retval = read ()
     %
     %retval is of type ImageRgbFloat. 
-      [varargout{1:nargout}] = yarpMEX(2520, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2506, self, varargin{:});
     end
     function varargout = lastRead(self,varargin)
     %Usage: retval = lastRead ()
     %
     %retval is of type ImageRgbFloat. 
-      [varargout{1:nargout}] = yarpMEX(2521, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2507, self, varargin{:});
     end
     function varargout = isClosed(self,varargin)
     %Usage: retval = isClosed ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2522, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2508, self, varargin{:});
     end
     function varargout = setReplier(self,varargin)
     %Usage: setReplier (reader)
     %
     %reader is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(2523, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2509, self, varargin{:});
     end
     function varargout = setReader(self,varargin)
     %Usage: setReader (reader)
     %
     %reader is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(2524, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2510, self, varargin{:});
     end
     function varargout = setAdminReader(self,varargin)
     %Usage: setAdminReader (reader)
     %
     %reader is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(2525, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2511, self, varargin{:});
     end
     function varargout = onRead(self,varargin)
     %Usage: onRead (datum)
     %
     %datum is of type ImageRgbFloat. 
-      [varargout{1:nargout}] = yarpMEX(2526, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2512, self, varargin{:});
     end
     function varargout = useCallback(self,varargin)
     %Usage: useCallback ()
     %
-      [varargout{1:nargout}] = yarpMEX(2527, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2513, self, varargin{:});
     end
     function varargout = disableCallback(self,varargin)
     %Usage: disableCallback ()
     %
-      [varargout{1:nargout}] = yarpMEX(2528, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2514, self, varargin{:});
     end
     function varargout = setEnvelope(self,varargin)
     %Usage: retval = setEnvelope (envelope)
     %
     %envelope is of type PortWriter. envelope is of type PortWriter. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2529, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2515, self, varargin{:});
     end
     function varargout = getEnvelope(self,varargin)
     %Usage: retval = getEnvelope (envelope)
     %
     %envelope is of type PortReader. envelope is of type PortReader. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2530, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2516, self, varargin{:});
     end
     function varargout = getInputCount(self,varargin)
     %Usage: retval = getInputCount ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(2531, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2517, self, varargin{:});
     end
     function varargout = getOutputCount(self,varargin)
     %Usage: retval = getOutputCount ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(2532, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2518, self, varargin{:});
     end
     function varargout = isWriting(self,varargin)
     %Usage: retval = isWriting ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2533, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2519, self, varargin{:});
     end
     function varargout = getReport(self,varargin)
     %Usage: getReport (reporter)
     %
     %reporter is of type PortReport. 
-      [varargout{1:nargout}] = yarpMEX(2534, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2520, self, varargin{:});
     end
     function varargout = setReporter(self,varargin)
     %Usage: setReporter (reporter)
     %
     %reporter is of type PortReport. 
-      [varargout{1:nargout}] = yarpMEX(2535, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2521, self, varargin{:});
     end
     function varargout = resetReporter(self,varargin)
     %Usage: resetReporter ()
     %
-      [varargout{1:nargout}] = yarpMEX(2536, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2522, self, varargin{:});
     end
     function varargout = acquire(self,varargin)
     %Usage: retval = acquire ()
     %
     %retval is of type void *. 
-      [varargout{1:nargout}] = yarpMEX(2537, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2523, self, varargin{:});
     end
     function varargout = release(self,varargin)
     %Usage: release (handle)
     %
     %handle is of type void *. 
-      [varargout{1:nargout}] = yarpMEX(2538, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2524, self, varargin{:});
     end
     function varargout = setTargetPeriod(self,varargin)
     %Usage: setTargetPeriod (period)
     %
     %period is of type double. 
-      [varargout{1:nargout}] = yarpMEX(2539, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2525, self, varargin{:});
     end
     function varargout = getType(self,varargin)
     %Usage: retval = getType ()
     %
-    %retval is of type Type. 
-      [varargout{1:nargout}] = yarpMEX(2540, self, varargin{:});
+    %retval is of type yarp::os::Type. 
+      [varargout{1:nargout}] = yarpMEX(2526, self, varargin{:});
     end
     function varargout = promiseType(self,varargin)
     %Usage: promiseType (typ)
     %
-    %typ is of type Type const &. 
-      [varargout{1:nargout}] = yarpMEX(2541, self, varargin{:});
+    %typ is of type yarp::os::Type const &. 
+      [varargout{1:nargout}] = yarpMEX(2527, self, varargin{:});
     end
     function varargout = setInputMode(self,varargin)
     %Usage: setInputMode (expectInput)
     %
     %expectInput is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2542, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2528, self, varargin{:});
     end
     function varargout = setOutputMode(self,varargin)
     %Usage: setOutputMode (expectOutput)
     %
     %expectOutput is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2543, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2529, self, varargin{:});
     end
     function varargout = setRpcMode(self,varargin)
     %Usage: setRpcMode (expectRpc)
     %
     %expectRpc is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2544, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2530, self, varargin{:});
     end
     function varargout = acquireProperties(self,varargin)
     %Usage: retval = acquireProperties (readOnly)
     %
     %readOnly is of type bool. readOnly is of type bool. retval is of type Property. 
-      [varargout{1:nargout}] = yarpMEX(2545, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2531, self, varargin{:});
     end
     function varargout = releaseProperties(self,varargin)
     %Usage: releaseProperties (prop)
     %
     %prop is of type Property. 
-      [varargout{1:nargout}] = yarpMEX(2546, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2532, self, varargin{:});
     end
     function varargout = includeNodeInName(self,varargin)
     %Usage: includeNodeInName (flag)
     %
     %flag is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2547, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2533, self, varargin{:});
     end
     function varargout = setCallbackLock(self,varargin)
     %Usage: retval = setCallbackLock (mutex)
     %
     %mutex is of type yarp::os::Mutex *. mutex is of type yarp::os::Mutex *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2548, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2534, self, varargin{:});
     end
     function varargout = removeCallbackLock(self,varargin)
     %Usage: retval = removeCallbackLock ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2549, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2535, self, varargin{:});
     end
     function varargout = lockCallback(self,varargin)
     %Usage: retval = lockCallback ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2550, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2536, self, varargin{:});
     end
     function varargout = tryLockCallback(self,varargin)
     %Usage: retval = tryLockCallback ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2551, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2537, self, varargin{:});
     end
     function varargout = unlockCallback(self,varargin)
     %Usage: unlockCallback ()
     %
-      [varargout{1:nargout}] = yarpMEX(2552, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2538, self, varargin{:});
     end
   end
   methods(Static)

--- a/matlab/autogenerated/+yarp/BufferedPortImageRgbFloat.m
+++ b/matlab/autogenerated/+yarp/BufferedPortImageRgbFloat.m
@@ -1,4 +1,4 @@
-classdef BufferedPortImageRgbFloat < SwigRef
+classdef BufferedPortImageRgbFloat < yarp.Contactable & yarp.TypedReaderImageRgbFloat & yarp.TypedReaderCallbackImageRgbFloat
     %Usage: BufferedPortImageRgbFloat ()
     %
   methods
@@ -6,6 +6,9 @@ classdef BufferedPortImageRgbFloat < SwigRef
       this = yarpMEX(3, self);
     end
     function self = BufferedPortImageRgbFloat(varargin)
+      self@yarp.Contactable(SwigRef.Null);
+      self@yarp.TypedReaderImageRgbFloat(SwigRef.Null);
+      self@yarp.TypedReaderCallbackImageRgbFloat(SwigRef.Null);
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;

--- a/matlab/autogenerated/+yarp/BufferedPortImageRgba.m
+++ b/matlab/autogenerated/+yarp/BufferedPortImageRgba.m
@@ -1,4 +1,4 @@
-classdef BufferedPortImageRgba < SwigRef
+classdef BufferedPortImageRgba < yarp.Contactable & yarp.TypedReaderImageRgba & yarp.TypedReaderCallbackImageRgba
     %Usage: BufferedPortImageRgba ()
     %
   methods
@@ -6,6 +6,9 @@ classdef BufferedPortImageRgba < SwigRef
       this = yarpMEX(3, self);
     end
     function self = BufferedPortImageRgba(varargin)
+      self@yarp.Contactable(SwigRef.Null);
+      self@yarp.TypedReaderImageRgba(SwigRef.Null);
+      self@yarp.TypedReaderCallbackImageRgba(SwigRef.Null);
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;

--- a/matlab/autogenerated/+yarp/BufferedPortImageRgba.m
+++ b/matlab/autogenerated/+yarp/BufferedPortImageRgba.m
@@ -14,14 +14,14 @@ classdef BufferedPortImageRgba < yarp.Contactable & yarp.TypedReaderImageRgba & 
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(2011, varargin{:});
+        tmp = yarpMEX(1997, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(2012, self);
+        yarpMEX(1998, self);
         self.SwigClear();
       end
     end
@@ -29,266 +29,266 @@ classdef BufferedPortImageRgba < yarp.Contactable & yarp.TypedReaderImageRgba & 
     %Usage: retval = addOutput (contact)
     %
     %contact is of type Contact. contact is of type Contact. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2013, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1999, self, varargin{:});
     end
     function varargout = close(self,varargin)
     %Usage: close ()
     %
-      [varargout{1:nargout}] = yarpMEX(2014, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2000, self, varargin{:});
     end
     function varargout = interrupt(self,varargin)
     %Usage: interrupt ()
     %
-      [varargout{1:nargout}] = yarpMEX(2015, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2001, self, varargin{:});
     end
     function varargout = resume(self,varargin)
     %Usage: resume ()
     %
-      [varargout{1:nargout}] = yarpMEX(2016, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2002, self, varargin{:});
     end
     function varargout = getPendingReads(self,varargin)
     %Usage: retval = getPendingReads ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(2017, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2003, self, varargin{:});
     end
     function varargout = where(self,varargin)
     %Usage: retval = where ()
     %
     %retval is of type Contact. 
-      [varargout{1:nargout}] = yarpMEX(2018, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2004, self, varargin{:});
     end
     function varargout = getName(self,varargin)
     %Usage: retval = getName ()
     %
     %retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(2019, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2005, self, varargin{:});
     end
     function varargout = prepare(self,varargin)
     %Usage: retval = prepare ()
     %
     %retval is of type ImageRgba. 
-      [varargout{1:nargout}] = yarpMEX(2020, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2006, self, varargin{:});
     end
     function varargout = unprepare(self,varargin)
     %Usage: retval = unprepare ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2021, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2007, self, varargin{:});
     end
     function varargout = write(self,varargin)
     %Usage: write ()
     %
-      [varargout{1:nargout}] = yarpMEX(2022, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2008, self, varargin{:});
     end
     function varargout = writeStrict(self,varargin)
     %Usage: writeStrict ()
     %
-      [varargout{1:nargout}] = yarpMEX(2023, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2009, self, varargin{:});
     end
     function varargout = waitForWrite(self,varargin)
     %Usage: waitForWrite ()
     %
-      [varargout{1:nargout}] = yarpMEX(2024, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2010, self, varargin{:});
     end
     function varargout = setStrict(self,varargin)
     %Usage: setStrict ()
     %
-      [varargout{1:nargout}] = yarpMEX(2025, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2011, self, varargin{:});
     end
     function varargout = read(self,varargin)
     %Usage: retval = read ()
     %
     %retval is of type ImageRgba. 
-      [varargout{1:nargout}] = yarpMEX(2026, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2012, self, varargin{:});
     end
     function varargout = lastRead(self,varargin)
     %Usage: retval = lastRead ()
     %
     %retval is of type ImageRgba. 
-      [varargout{1:nargout}] = yarpMEX(2027, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2013, self, varargin{:});
     end
     function varargout = isClosed(self,varargin)
     %Usage: retval = isClosed ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2028, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2014, self, varargin{:});
     end
     function varargout = setReplier(self,varargin)
     %Usage: setReplier (reader)
     %
     %reader is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(2029, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2015, self, varargin{:});
     end
     function varargout = setReader(self,varargin)
     %Usage: setReader (reader)
     %
     %reader is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(2030, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2016, self, varargin{:});
     end
     function varargout = setAdminReader(self,varargin)
     %Usage: setAdminReader (reader)
     %
     %reader is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(2031, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2017, self, varargin{:});
     end
     function varargout = onRead(self,varargin)
     %Usage: onRead (datum)
     %
     %datum is of type ImageRgba. 
-      [varargout{1:nargout}] = yarpMEX(2032, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2018, self, varargin{:});
     end
     function varargout = useCallback(self,varargin)
     %Usage: useCallback ()
     %
-      [varargout{1:nargout}] = yarpMEX(2033, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2019, self, varargin{:});
     end
     function varargout = disableCallback(self,varargin)
     %Usage: disableCallback ()
     %
-      [varargout{1:nargout}] = yarpMEX(2034, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2020, self, varargin{:});
     end
     function varargout = setEnvelope(self,varargin)
     %Usage: retval = setEnvelope (envelope)
     %
     %envelope is of type PortWriter. envelope is of type PortWriter. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2035, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2021, self, varargin{:});
     end
     function varargout = getEnvelope(self,varargin)
     %Usage: retval = getEnvelope (envelope)
     %
     %envelope is of type PortReader. envelope is of type PortReader. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2036, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2022, self, varargin{:});
     end
     function varargout = getInputCount(self,varargin)
     %Usage: retval = getInputCount ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(2037, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2023, self, varargin{:});
     end
     function varargout = getOutputCount(self,varargin)
     %Usage: retval = getOutputCount ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(2038, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2024, self, varargin{:});
     end
     function varargout = isWriting(self,varargin)
     %Usage: retval = isWriting ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2039, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2025, self, varargin{:});
     end
     function varargout = getReport(self,varargin)
     %Usage: getReport (reporter)
     %
     %reporter is of type PortReport. 
-      [varargout{1:nargout}] = yarpMEX(2040, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2026, self, varargin{:});
     end
     function varargout = setReporter(self,varargin)
     %Usage: setReporter (reporter)
     %
     %reporter is of type PortReport. 
-      [varargout{1:nargout}] = yarpMEX(2041, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2027, self, varargin{:});
     end
     function varargout = resetReporter(self,varargin)
     %Usage: resetReporter ()
     %
-      [varargout{1:nargout}] = yarpMEX(2042, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2028, self, varargin{:});
     end
     function varargout = acquire(self,varargin)
     %Usage: retval = acquire ()
     %
     %retval is of type void *. 
-      [varargout{1:nargout}] = yarpMEX(2043, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2029, self, varargin{:});
     end
     function varargout = release(self,varargin)
     %Usage: release (handle)
     %
     %handle is of type void *. 
-      [varargout{1:nargout}] = yarpMEX(2044, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2030, self, varargin{:});
     end
     function varargout = setTargetPeriod(self,varargin)
     %Usage: setTargetPeriod (period)
     %
     %period is of type double. 
-      [varargout{1:nargout}] = yarpMEX(2045, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2031, self, varargin{:});
     end
     function varargout = getType(self,varargin)
     %Usage: retval = getType ()
     %
-    %retval is of type Type. 
-      [varargout{1:nargout}] = yarpMEX(2046, self, varargin{:});
+    %retval is of type yarp::os::Type. 
+      [varargout{1:nargout}] = yarpMEX(2032, self, varargin{:});
     end
     function varargout = promiseType(self,varargin)
     %Usage: promiseType (typ)
     %
-    %typ is of type Type const &. 
-      [varargout{1:nargout}] = yarpMEX(2047, self, varargin{:});
+    %typ is of type yarp::os::Type const &. 
+      [varargout{1:nargout}] = yarpMEX(2033, self, varargin{:});
     end
     function varargout = setInputMode(self,varargin)
     %Usage: setInputMode (expectInput)
     %
     %expectInput is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2048, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2034, self, varargin{:});
     end
     function varargout = setOutputMode(self,varargin)
     %Usage: setOutputMode (expectOutput)
     %
     %expectOutput is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2049, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2035, self, varargin{:});
     end
     function varargout = setRpcMode(self,varargin)
     %Usage: setRpcMode (expectRpc)
     %
     %expectRpc is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2050, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2036, self, varargin{:});
     end
     function varargout = acquireProperties(self,varargin)
     %Usage: retval = acquireProperties (readOnly)
     %
     %readOnly is of type bool. readOnly is of type bool. retval is of type Property. 
-      [varargout{1:nargout}] = yarpMEX(2051, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2037, self, varargin{:});
     end
     function varargout = releaseProperties(self,varargin)
     %Usage: releaseProperties (prop)
     %
     %prop is of type Property. 
-      [varargout{1:nargout}] = yarpMEX(2052, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2038, self, varargin{:});
     end
     function varargout = includeNodeInName(self,varargin)
     %Usage: includeNodeInName (flag)
     %
     %flag is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2053, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2039, self, varargin{:});
     end
     function varargout = setCallbackLock(self,varargin)
     %Usage: retval = setCallbackLock (mutex)
     %
     %mutex is of type yarp::os::Mutex *. mutex is of type yarp::os::Mutex *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2054, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2040, self, varargin{:});
     end
     function varargout = removeCallbackLock(self,varargin)
     %Usage: retval = removeCallbackLock ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2055, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2041, self, varargin{:});
     end
     function varargout = lockCallback(self,varargin)
     %Usage: retval = lockCallback ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2056, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2042, self, varargin{:});
     end
     function varargout = tryLockCallback(self,varargin)
     %Usage: retval = tryLockCallback ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2057, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2043, self, varargin{:});
     end
     function varargout = unlockCallback(self,varargin)
     %Usage: unlockCallback ()
     %
-      [varargout{1:nargout}] = yarpMEX(2058, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2044, self, varargin{:});
     end
   end
   methods(Static)

--- a/matlab/autogenerated/+yarp/BufferedPortProperty.m
+++ b/matlab/autogenerated/+yarp/BufferedPortProperty.m
@@ -14,14 +14,14 @@ classdef BufferedPortProperty < yarp.Contactable & yarp.TypedReaderProperty & ya
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(744, varargin{:});
+        tmp = yarpMEX(730, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(745, self);
+        yarpMEX(731, self);
         self.SwigClear();
       end
     end
@@ -29,266 +29,266 @@ classdef BufferedPortProperty < yarp.Contactable & yarp.TypedReaderProperty & ya
     %Usage: retval = addOutput (contact)
     %
     %contact is of type Contact. contact is of type Contact. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(746, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(732, self, varargin{:});
     end
     function varargout = close(self,varargin)
     %Usage: close ()
     %
-      [varargout{1:nargout}] = yarpMEX(747, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(733, self, varargin{:});
     end
     function varargout = interrupt(self,varargin)
     %Usage: interrupt ()
     %
-      [varargout{1:nargout}] = yarpMEX(748, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(734, self, varargin{:});
     end
     function varargout = resume(self,varargin)
     %Usage: resume ()
     %
-      [varargout{1:nargout}] = yarpMEX(749, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(735, self, varargin{:});
     end
     function varargout = getPendingReads(self,varargin)
     %Usage: retval = getPendingReads ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(750, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(736, self, varargin{:});
     end
     function varargout = where(self,varargin)
     %Usage: retval = where ()
     %
     %retval is of type Contact. 
-      [varargout{1:nargout}] = yarpMEX(751, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(737, self, varargin{:});
     end
     function varargout = getName(self,varargin)
     %Usage: retval = getName ()
     %
     %retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(752, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(738, self, varargin{:});
     end
     function varargout = prepare(self,varargin)
     %Usage: retval = prepare ()
     %
     %retval is of type Property. 
-      [varargout{1:nargout}] = yarpMEX(753, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(739, self, varargin{:});
     end
     function varargout = unprepare(self,varargin)
     %Usage: retval = unprepare ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(754, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(740, self, varargin{:});
     end
     function varargout = write(self,varargin)
     %Usage: write ()
     %
-      [varargout{1:nargout}] = yarpMEX(755, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(741, self, varargin{:});
     end
     function varargout = writeStrict(self,varargin)
     %Usage: writeStrict ()
     %
-      [varargout{1:nargout}] = yarpMEX(756, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(742, self, varargin{:});
     end
     function varargout = waitForWrite(self,varargin)
     %Usage: waitForWrite ()
     %
-      [varargout{1:nargout}] = yarpMEX(757, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(743, self, varargin{:});
     end
     function varargout = setStrict(self,varargin)
     %Usage: setStrict ()
     %
-      [varargout{1:nargout}] = yarpMEX(758, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(744, self, varargin{:});
     end
     function varargout = read(self,varargin)
     %Usage: retval = read ()
     %
     %retval is of type Property. 
-      [varargout{1:nargout}] = yarpMEX(759, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(745, self, varargin{:});
     end
     function varargout = lastRead(self,varargin)
     %Usage: retval = lastRead ()
     %
     %retval is of type Property. 
-      [varargout{1:nargout}] = yarpMEX(760, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(746, self, varargin{:});
     end
     function varargout = isClosed(self,varargin)
     %Usage: retval = isClosed ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(761, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(747, self, varargin{:});
     end
     function varargout = setReplier(self,varargin)
     %Usage: setReplier (reader)
     %
     %reader is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(762, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(748, self, varargin{:});
     end
     function varargout = setReader(self,varargin)
     %Usage: setReader (reader)
     %
     %reader is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(763, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(749, self, varargin{:});
     end
     function varargout = setAdminReader(self,varargin)
     %Usage: setAdminReader (reader)
     %
     %reader is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(764, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(750, self, varargin{:});
     end
     function varargout = onRead(self,varargin)
     %Usage: onRead (datum)
     %
     %datum is of type Property. 
-      [varargout{1:nargout}] = yarpMEX(765, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(751, self, varargin{:});
     end
     function varargout = useCallback(self,varargin)
     %Usage: useCallback ()
     %
-      [varargout{1:nargout}] = yarpMEX(766, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(752, self, varargin{:});
     end
     function varargout = disableCallback(self,varargin)
     %Usage: disableCallback ()
     %
-      [varargout{1:nargout}] = yarpMEX(767, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(753, self, varargin{:});
     end
     function varargout = setEnvelope(self,varargin)
     %Usage: retval = setEnvelope (envelope)
     %
     %envelope is of type PortWriter. envelope is of type PortWriter. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(768, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(754, self, varargin{:});
     end
     function varargout = getEnvelope(self,varargin)
     %Usage: retval = getEnvelope (envelope)
     %
     %envelope is of type PortReader. envelope is of type PortReader. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(769, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(755, self, varargin{:});
     end
     function varargout = getInputCount(self,varargin)
     %Usage: retval = getInputCount ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(770, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(756, self, varargin{:});
     end
     function varargout = getOutputCount(self,varargin)
     %Usage: retval = getOutputCount ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(771, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(757, self, varargin{:});
     end
     function varargout = isWriting(self,varargin)
     %Usage: retval = isWriting ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(772, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(758, self, varargin{:});
     end
     function varargout = getReport(self,varargin)
     %Usage: getReport (reporter)
     %
     %reporter is of type PortReport. 
-      [varargout{1:nargout}] = yarpMEX(773, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(759, self, varargin{:});
     end
     function varargout = setReporter(self,varargin)
     %Usage: setReporter (reporter)
     %
     %reporter is of type PortReport. 
-      [varargout{1:nargout}] = yarpMEX(774, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(760, self, varargin{:});
     end
     function varargout = resetReporter(self,varargin)
     %Usage: resetReporter ()
     %
-      [varargout{1:nargout}] = yarpMEX(775, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(761, self, varargin{:});
     end
     function varargout = acquire(self,varargin)
     %Usage: retval = acquire ()
     %
     %retval is of type void *. 
-      [varargout{1:nargout}] = yarpMEX(776, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(762, self, varargin{:});
     end
     function varargout = release(self,varargin)
     %Usage: release (handle)
     %
     %handle is of type void *. 
-      [varargout{1:nargout}] = yarpMEX(777, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(763, self, varargin{:});
     end
     function varargout = setTargetPeriod(self,varargin)
     %Usage: setTargetPeriod (period)
     %
     %period is of type double. 
-      [varargout{1:nargout}] = yarpMEX(778, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(764, self, varargin{:});
     end
     function varargout = getType(self,varargin)
     %Usage: retval = getType ()
     %
-    %retval is of type Type. 
-      [varargout{1:nargout}] = yarpMEX(779, self, varargin{:});
+    %retval is of type yarp::os::Type. 
+      [varargout{1:nargout}] = yarpMEX(765, self, varargin{:});
     end
     function varargout = promiseType(self,varargin)
     %Usage: promiseType (typ)
     %
-    %typ is of type Type const &. 
-      [varargout{1:nargout}] = yarpMEX(780, self, varargin{:});
+    %typ is of type yarp::os::Type const &. 
+      [varargout{1:nargout}] = yarpMEX(766, self, varargin{:});
     end
     function varargout = setInputMode(self,varargin)
     %Usage: setInputMode (expectInput)
     %
     %expectInput is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(781, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(767, self, varargin{:});
     end
     function varargout = setOutputMode(self,varargin)
     %Usage: setOutputMode (expectOutput)
     %
     %expectOutput is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(782, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(768, self, varargin{:});
     end
     function varargout = setRpcMode(self,varargin)
     %Usage: setRpcMode (expectRpc)
     %
     %expectRpc is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(783, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(769, self, varargin{:});
     end
     function varargout = acquireProperties(self,varargin)
     %Usage: retval = acquireProperties (readOnly)
     %
     %readOnly is of type bool. readOnly is of type bool. retval is of type Property. 
-      [varargout{1:nargout}] = yarpMEX(784, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(770, self, varargin{:});
     end
     function varargout = releaseProperties(self,varargin)
     %Usage: releaseProperties (prop)
     %
     %prop is of type Property. 
-      [varargout{1:nargout}] = yarpMEX(785, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(771, self, varargin{:});
     end
     function varargout = includeNodeInName(self,varargin)
     %Usage: includeNodeInName (flag)
     %
     %flag is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(786, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(772, self, varargin{:});
     end
     function varargout = setCallbackLock(self,varargin)
     %Usage: retval = setCallbackLock (mutex)
     %
     %mutex is of type yarp::os::Mutex *. mutex is of type yarp::os::Mutex *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(787, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(773, self, varargin{:});
     end
     function varargout = removeCallbackLock(self,varargin)
     %Usage: retval = removeCallbackLock ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(788, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(774, self, varargin{:});
     end
     function varargout = lockCallback(self,varargin)
     %Usage: retval = lockCallback ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(789, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(775, self, varargin{:});
     end
     function varargout = tryLockCallback(self,varargin)
     %Usage: retval = tryLockCallback ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(790, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(776, self, varargin{:});
     end
     function varargout = unlockCallback(self,varargin)
     %Usage: unlockCallback ()
     %
-      [varargout{1:nargout}] = yarpMEX(791, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(777, self, varargin{:});
     end
   end
   methods(Static)

--- a/matlab/autogenerated/+yarp/BufferedPortProperty.m
+++ b/matlab/autogenerated/+yarp/BufferedPortProperty.m
@@ -1,4 +1,4 @@
-classdef BufferedPortProperty < SwigRef
+classdef BufferedPortProperty < yarp.Contactable & yarp.TypedReaderProperty & yarp.PropertyCallback
     %Usage: BufferedPortProperty ()
     %
   methods
@@ -6,6 +6,9 @@ classdef BufferedPortProperty < SwigRef
       this = yarpMEX(3, self);
     end
     function self = BufferedPortProperty(varargin)
+      self@yarp.Contactable(SwigRef.Null);
+      self@yarp.TypedReaderProperty(SwigRef.Null);
+      self@yarp.PropertyCallback(SwigRef.Null);
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;

--- a/matlab/autogenerated/+yarp/BufferedPortSound.m
+++ b/matlab/autogenerated/+yarp/BufferedPortSound.m
@@ -1,4 +1,4 @@
-classdef BufferedPortSound < SwigRef
+classdef BufferedPortSound < yarp.Contactable & yarp.TypedReaderSound & yarp.TypedReaderCallbackSound
     %Usage: BufferedPortSound ()
     %
   methods
@@ -6,6 +6,9 @@ classdef BufferedPortSound < SwigRef
       this = yarpMEX(3, self);
     end
     function self = BufferedPortSound(varargin)
+      self@yarp.Contactable(SwigRef.Null);
+      self@yarp.TypedReaderSound(SwigRef.Null);
+      self@yarp.TypedReaderCallbackSound(SwigRef.Null);
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;

--- a/matlab/autogenerated/+yarp/BufferedPortSound.m
+++ b/matlab/autogenerated/+yarp/BufferedPortSound.m
@@ -14,14 +14,14 @@ classdef BufferedPortSound < yarp.Contactable & yarp.TypedReaderSound & yarp.Typ
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(2294, varargin{:});
+        tmp = yarpMEX(2280, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(2295, self);
+        yarpMEX(2281, self);
         self.SwigClear();
       end
     end
@@ -29,266 +29,266 @@ classdef BufferedPortSound < yarp.Contactable & yarp.TypedReaderSound & yarp.Typ
     %Usage: retval = addOutput (contact)
     %
     %contact is of type Contact. contact is of type Contact. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2296, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2282, self, varargin{:});
     end
     function varargout = close(self,varargin)
     %Usage: close ()
     %
-      [varargout{1:nargout}] = yarpMEX(2297, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2283, self, varargin{:});
     end
     function varargout = interrupt(self,varargin)
     %Usage: interrupt ()
     %
-      [varargout{1:nargout}] = yarpMEX(2298, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2284, self, varargin{:});
     end
     function varargout = resume(self,varargin)
     %Usage: resume ()
     %
-      [varargout{1:nargout}] = yarpMEX(2299, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2285, self, varargin{:});
     end
     function varargout = getPendingReads(self,varargin)
     %Usage: retval = getPendingReads ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(2300, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2286, self, varargin{:});
     end
     function varargout = where(self,varargin)
     %Usage: retval = where ()
     %
     %retval is of type Contact. 
-      [varargout{1:nargout}] = yarpMEX(2301, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2287, self, varargin{:});
     end
     function varargout = getName(self,varargin)
     %Usage: retval = getName ()
     %
     %retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(2302, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2288, self, varargin{:});
     end
     function varargout = prepare(self,varargin)
     %Usage: retval = prepare ()
     %
     %retval is of type Sound. 
-      [varargout{1:nargout}] = yarpMEX(2303, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2289, self, varargin{:});
     end
     function varargout = unprepare(self,varargin)
     %Usage: retval = unprepare ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2304, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2290, self, varargin{:});
     end
     function varargout = write(self,varargin)
     %Usage: write ()
     %
-      [varargout{1:nargout}] = yarpMEX(2305, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2291, self, varargin{:});
     end
     function varargout = writeStrict(self,varargin)
     %Usage: writeStrict ()
     %
-      [varargout{1:nargout}] = yarpMEX(2306, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2292, self, varargin{:});
     end
     function varargout = waitForWrite(self,varargin)
     %Usage: waitForWrite ()
     %
-      [varargout{1:nargout}] = yarpMEX(2307, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2293, self, varargin{:});
     end
     function varargout = setStrict(self,varargin)
     %Usage: setStrict ()
     %
-      [varargout{1:nargout}] = yarpMEX(2308, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2294, self, varargin{:});
     end
     function varargout = read(self,varargin)
     %Usage: retval = read ()
     %
     %retval is of type Sound. 
-      [varargout{1:nargout}] = yarpMEX(2309, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2295, self, varargin{:});
     end
     function varargout = lastRead(self,varargin)
     %Usage: retval = lastRead ()
     %
     %retval is of type Sound. 
-      [varargout{1:nargout}] = yarpMEX(2310, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2296, self, varargin{:});
     end
     function varargout = isClosed(self,varargin)
     %Usage: retval = isClosed ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2311, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2297, self, varargin{:});
     end
     function varargout = setReplier(self,varargin)
     %Usage: setReplier (reader)
     %
     %reader is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(2312, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2298, self, varargin{:});
     end
     function varargout = setReader(self,varargin)
     %Usage: setReader (reader)
     %
     %reader is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(2313, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2299, self, varargin{:});
     end
     function varargout = setAdminReader(self,varargin)
     %Usage: setAdminReader (reader)
     %
     %reader is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(2314, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2300, self, varargin{:});
     end
     function varargout = onRead(self,varargin)
     %Usage: onRead (datum)
     %
     %datum is of type Sound. 
-      [varargout{1:nargout}] = yarpMEX(2315, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2301, self, varargin{:});
     end
     function varargout = useCallback(self,varargin)
     %Usage: useCallback ()
     %
-      [varargout{1:nargout}] = yarpMEX(2316, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2302, self, varargin{:});
     end
     function varargout = disableCallback(self,varargin)
     %Usage: disableCallback ()
     %
-      [varargout{1:nargout}] = yarpMEX(2317, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2303, self, varargin{:});
     end
     function varargout = setEnvelope(self,varargin)
     %Usage: retval = setEnvelope (envelope)
     %
     %envelope is of type PortWriter. envelope is of type PortWriter. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2318, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2304, self, varargin{:});
     end
     function varargout = getEnvelope(self,varargin)
     %Usage: retval = getEnvelope (envelope)
     %
     %envelope is of type PortReader. envelope is of type PortReader. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2319, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2305, self, varargin{:});
     end
     function varargout = getInputCount(self,varargin)
     %Usage: retval = getInputCount ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(2320, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2306, self, varargin{:});
     end
     function varargout = getOutputCount(self,varargin)
     %Usage: retval = getOutputCount ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(2321, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2307, self, varargin{:});
     end
     function varargout = isWriting(self,varargin)
     %Usage: retval = isWriting ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2322, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2308, self, varargin{:});
     end
     function varargout = getReport(self,varargin)
     %Usage: getReport (reporter)
     %
     %reporter is of type PortReport. 
-      [varargout{1:nargout}] = yarpMEX(2323, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2309, self, varargin{:});
     end
     function varargout = setReporter(self,varargin)
     %Usage: setReporter (reporter)
     %
     %reporter is of type PortReport. 
-      [varargout{1:nargout}] = yarpMEX(2324, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2310, self, varargin{:});
     end
     function varargout = resetReporter(self,varargin)
     %Usage: resetReporter ()
     %
-      [varargout{1:nargout}] = yarpMEX(2325, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2311, self, varargin{:});
     end
     function varargout = acquire(self,varargin)
     %Usage: retval = acquire ()
     %
     %retval is of type void *. 
-      [varargout{1:nargout}] = yarpMEX(2326, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2312, self, varargin{:});
     end
     function varargout = release(self,varargin)
     %Usage: release (handle)
     %
     %handle is of type void *. 
-      [varargout{1:nargout}] = yarpMEX(2327, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2313, self, varargin{:});
     end
     function varargout = setTargetPeriod(self,varargin)
     %Usage: setTargetPeriod (period)
     %
     %period is of type double. 
-      [varargout{1:nargout}] = yarpMEX(2328, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2314, self, varargin{:});
     end
     function varargout = getType(self,varargin)
     %Usage: retval = getType ()
     %
-    %retval is of type Type. 
-      [varargout{1:nargout}] = yarpMEX(2329, self, varargin{:});
+    %retval is of type yarp::os::Type. 
+      [varargout{1:nargout}] = yarpMEX(2315, self, varargin{:});
     end
     function varargout = promiseType(self,varargin)
     %Usage: promiseType (typ)
     %
-    %typ is of type Type const &. 
-      [varargout{1:nargout}] = yarpMEX(2330, self, varargin{:});
+    %typ is of type yarp::os::Type const &. 
+      [varargout{1:nargout}] = yarpMEX(2316, self, varargin{:});
     end
     function varargout = setInputMode(self,varargin)
     %Usage: setInputMode (expectInput)
     %
     %expectInput is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2331, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2317, self, varargin{:});
     end
     function varargout = setOutputMode(self,varargin)
     %Usage: setOutputMode (expectOutput)
     %
     %expectOutput is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2332, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2318, self, varargin{:});
     end
     function varargout = setRpcMode(self,varargin)
     %Usage: setRpcMode (expectRpc)
     %
     %expectRpc is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2333, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2319, self, varargin{:});
     end
     function varargout = acquireProperties(self,varargin)
     %Usage: retval = acquireProperties (readOnly)
     %
     %readOnly is of type bool. readOnly is of type bool. retval is of type Property. 
-      [varargout{1:nargout}] = yarpMEX(2334, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2320, self, varargin{:});
     end
     function varargout = releaseProperties(self,varargin)
     %Usage: releaseProperties (prop)
     %
     %prop is of type Property. 
-      [varargout{1:nargout}] = yarpMEX(2335, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2321, self, varargin{:});
     end
     function varargout = includeNodeInName(self,varargin)
     %Usage: includeNodeInName (flag)
     %
     %flag is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2336, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2322, self, varargin{:});
     end
     function varargout = setCallbackLock(self,varargin)
     %Usage: retval = setCallbackLock (mutex)
     %
     %mutex is of type yarp::os::Mutex *. mutex is of type yarp::os::Mutex *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2337, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2323, self, varargin{:});
     end
     function varargout = removeCallbackLock(self,varargin)
     %Usage: retval = removeCallbackLock ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2338, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2324, self, varargin{:});
     end
     function varargout = lockCallback(self,varargin)
     %Usage: retval = lockCallback ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2339, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2325, self, varargin{:});
     end
     function varargout = tryLockCallback(self,varargin)
     %Usage: retval = tryLockCallback ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2340, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2326, self, varargin{:});
     end
     function varargout = unlockCallback(self,varargin)
     %Usage: unlockCallback ()
     %
-      [varargout{1:nargout}] = yarpMEX(2341, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2327, self, varargin{:});
     end
   end
   methods(Static)

--- a/matlab/autogenerated/+yarp/BufferedPortVector.m
+++ b/matlab/autogenerated/+yarp/BufferedPortVector.m
@@ -14,14 +14,14 @@ classdef BufferedPortVector < yarp.Contactable & yarp.TypedReaderVector & yarp.T
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(2359, varargin{:});
+        tmp = yarpMEX(2345, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(2360, self);
+        yarpMEX(2346, self);
         self.SwigClear();
       end
     end
@@ -29,266 +29,266 @@ classdef BufferedPortVector < yarp.Contactable & yarp.TypedReaderVector & yarp.T
     %Usage: retval = addOutput (contact)
     %
     %contact is of type Contact. contact is of type Contact. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2361, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2347, self, varargin{:});
     end
     function varargout = close(self,varargin)
     %Usage: close ()
     %
-      [varargout{1:nargout}] = yarpMEX(2362, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2348, self, varargin{:});
     end
     function varargout = interrupt(self,varargin)
     %Usage: interrupt ()
     %
-      [varargout{1:nargout}] = yarpMEX(2363, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2349, self, varargin{:});
     end
     function varargout = resume(self,varargin)
     %Usage: resume ()
     %
-      [varargout{1:nargout}] = yarpMEX(2364, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2350, self, varargin{:});
     end
     function varargout = getPendingReads(self,varargin)
     %Usage: retval = getPendingReads ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(2365, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2351, self, varargin{:});
     end
     function varargout = where(self,varargin)
     %Usage: retval = where ()
     %
     %retval is of type Contact. 
-      [varargout{1:nargout}] = yarpMEX(2366, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2352, self, varargin{:});
     end
     function varargout = getName(self,varargin)
     %Usage: retval = getName ()
     %
     %retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(2367, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2353, self, varargin{:});
     end
     function varargout = prepare(self,varargin)
     %Usage: retval = prepare ()
     %
     %retval is of type Vector. 
-      [varargout{1:nargout}] = yarpMEX(2368, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2354, self, varargin{:});
     end
     function varargout = unprepare(self,varargin)
     %Usage: retval = unprepare ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2369, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2355, self, varargin{:});
     end
     function varargout = write(self,varargin)
     %Usage: write ()
     %
-      [varargout{1:nargout}] = yarpMEX(2370, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2356, self, varargin{:});
     end
     function varargout = writeStrict(self,varargin)
     %Usage: writeStrict ()
     %
-      [varargout{1:nargout}] = yarpMEX(2371, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2357, self, varargin{:});
     end
     function varargout = waitForWrite(self,varargin)
     %Usage: waitForWrite ()
     %
-      [varargout{1:nargout}] = yarpMEX(2372, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2358, self, varargin{:});
     end
     function varargout = setStrict(self,varargin)
     %Usage: setStrict ()
     %
-      [varargout{1:nargout}] = yarpMEX(2373, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2359, self, varargin{:});
     end
     function varargout = read(self,varargin)
     %Usage: retval = read ()
     %
     %retval is of type Vector. 
-      [varargout{1:nargout}] = yarpMEX(2374, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2360, self, varargin{:});
     end
     function varargout = lastRead(self,varargin)
     %Usage: retval = lastRead ()
     %
     %retval is of type Vector. 
-      [varargout{1:nargout}] = yarpMEX(2375, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2361, self, varargin{:});
     end
     function varargout = isClosed(self,varargin)
     %Usage: retval = isClosed ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2376, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2362, self, varargin{:});
     end
     function varargout = setReplier(self,varargin)
     %Usage: setReplier (reader)
     %
     %reader is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(2377, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2363, self, varargin{:});
     end
     function varargout = setReader(self,varargin)
     %Usage: setReader (reader)
     %
     %reader is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(2378, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2364, self, varargin{:});
     end
     function varargout = setAdminReader(self,varargin)
     %Usage: setAdminReader (reader)
     %
     %reader is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(2379, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2365, self, varargin{:});
     end
     function varargout = onRead(self,varargin)
     %Usage: onRead (datum)
     %
     %datum is of type Vector. 
-      [varargout{1:nargout}] = yarpMEX(2380, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2366, self, varargin{:});
     end
     function varargout = useCallback(self,varargin)
     %Usage: useCallback ()
     %
-      [varargout{1:nargout}] = yarpMEX(2381, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2367, self, varargin{:});
     end
     function varargout = disableCallback(self,varargin)
     %Usage: disableCallback ()
     %
-      [varargout{1:nargout}] = yarpMEX(2382, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2368, self, varargin{:});
     end
     function varargout = setEnvelope(self,varargin)
     %Usage: retval = setEnvelope (envelope)
     %
     %envelope is of type PortWriter. envelope is of type PortWriter. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2383, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2369, self, varargin{:});
     end
     function varargout = getEnvelope(self,varargin)
     %Usage: retval = getEnvelope (envelope)
     %
     %envelope is of type PortReader. envelope is of type PortReader. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2384, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2370, self, varargin{:});
     end
     function varargout = getInputCount(self,varargin)
     %Usage: retval = getInputCount ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(2385, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2371, self, varargin{:});
     end
     function varargout = getOutputCount(self,varargin)
     %Usage: retval = getOutputCount ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(2386, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2372, self, varargin{:});
     end
     function varargout = isWriting(self,varargin)
     %Usage: retval = isWriting ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2387, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2373, self, varargin{:});
     end
     function varargout = getReport(self,varargin)
     %Usage: getReport (reporter)
     %
     %reporter is of type PortReport. 
-      [varargout{1:nargout}] = yarpMEX(2388, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2374, self, varargin{:});
     end
     function varargout = setReporter(self,varargin)
     %Usage: setReporter (reporter)
     %
     %reporter is of type PortReport. 
-      [varargout{1:nargout}] = yarpMEX(2389, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2375, self, varargin{:});
     end
     function varargout = resetReporter(self,varargin)
     %Usage: resetReporter ()
     %
-      [varargout{1:nargout}] = yarpMEX(2390, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2376, self, varargin{:});
     end
     function varargout = acquire(self,varargin)
     %Usage: retval = acquire ()
     %
     %retval is of type void *. 
-      [varargout{1:nargout}] = yarpMEX(2391, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2377, self, varargin{:});
     end
     function varargout = release(self,varargin)
     %Usage: release (handle)
     %
     %handle is of type void *. 
-      [varargout{1:nargout}] = yarpMEX(2392, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2378, self, varargin{:});
     end
     function varargout = setTargetPeriod(self,varargin)
     %Usage: setTargetPeriod (period)
     %
     %period is of type double. 
-      [varargout{1:nargout}] = yarpMEX(2393, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2379, self, varargin{:});
     end
     function varargout = getType(self,varargin)
     %Usage: retval = getType ()
     %
-    %retval is of type Type. 
-      [varargout{1:nargout}] = yarpMEX(2394, self, varargin{:});
+    %retval is of type yarp::os::Type. 
+      [varargout{1:nargout}] = yarpMEX(2380, self, varargin{:});
     end
     function varargout = promiseType(self,varargin)
     %Usage: promiseType (typ)
     %
-    %typ is of type Type const &. 
-      [varargout{1:nargout}] = yarpMEX(2395, self, varargin{:});
+    %typ is of type yarp::os::Type const &. 
+      [varargout{1:nargout}] = yarpMEX(2381, self, varargin{:});
     end
     function varargout = setInputMode(self,varargin)
     %Usage: setInputMode (expectInput)
     %
     %expectInput is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2396, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2382, self, varargin{:});
     end
     function varargout = setOutputMode(self,varargin)
     %Usage: setOutputMode (expectOutput)
     %
     %expectOutput is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2397, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2383, self, varargin{:});
     end
     function varargout = setRpcMode(self,varargin)
     %Usage: setRpcMode (expectRpc)
     %
     %expectRpc is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2398, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2384, self, varargin{:});
     end
     function varargout = acquireProperties(self,varargin)
     %Usage: retval = acquireProperties (readOnly)
     %
     %readOnly is of type bool. readOnly is of type bool. retval is of type Property. 
-      [varargout{1:nargout}] = yarpMEX(2399, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2385, self, varargin{:});
     end
     function varargout = releaseProperties(self,varargin)
     %Usage: releaseProperties (prop)
     %
     %prop is of type Property. 
-      [varargout{1:nargout}] = yarpMEX(2400, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2386, self, varargin{:});
     end
     function varargout = includeNodeInName(self,varargin)
     %Usage: includeNodeInName (flag)
     %
     %flag is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2401, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2387, self, varargin{:});
     end
     function varargout = setCallbackLock(self,varargin)
     %Usage: retval = setCallbackLock (mutex)
     %
     %mutex is of type yarp::os::Mutex *. mutex is of type yarp::os::Mutex *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2402, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2388, self, varargin{:});
     end
     function varargout = removeCallbackLock(self,varargin)
     %Usage: retval = removeCallbackLock ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2403, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2389, self, varargin{:});
     end
     function varargout = lockCallback(self,varargin)
     %Usage: retval = lockCallback ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2404, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2390, self, varargin{:});
     end
     function varargout = tryLockCallback(self,varargin)
     %Usage: retval = tryLockCallback ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2405, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2391, self, varargin{:});
     end
     function varargout = unlockCallback(self,varargin)
     %Usage: unlockCallback ()
     %
-      [varargout{1:nargout}] = yarpMEX(2406, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2392, self, varargin{:});
     end
   end
   methods(Static)

--- a/matlab/autogenerated/+yarp/BufferedPortVector.m
+++ b/matlab/autogenerated/+yarp/BufferedPortVector.m
@@ -1,4 +1,4 @@
-classdef BufferedPortVector < SwigRef
+classdef BufferedPortVector < yarp.Contactable & yarp.TypedReaderVector & yarp.TypedReaderCallbackVector
     %Usage: BufferedPortVector ()
     %
   methods
@@ -6,6 +6,9 @@ classdef BufferedPortVector < SwigRef
       this = yarpMEX(3, self);
     end
     function self = BufferedPortVector(varargin)
+      self@yarp.Contactable(SwigRef.Null);
+      self@yarp.TypedReaderVector(SwigRef.Null);
+      self@yarp.TypedReaderCallbackVector(SwigRef.Null);
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;

--- a/matlab/autogenerated/+yarp/CalibrationParameters.m
+++ b/matlab/autogenerated/+yarp/CalibrationParameters.m
@@ -9,70 +9,70 @@ classdef CalibrationParameters < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(1226, self);
+        varargout{1} = yarpMEX(1212, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(1227, self, varargin{1});
+        yarpMEX(1213, self, varargin{1});
       end
     end
     function varargout = param1(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(1228, self);
+        varargout{1} = yarpMEX(1214, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(1229, self, varargin{1});
+        yarpMEX(1215, self, varargin{1});
       end
     end
     function varargout = param2(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(1230, self);
+        varargout{1} = yarpMEX(1216, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(1231, self, varargin{1});
+        yarpMEX(1217, self, varargin{1});
       end
     end
     function varargout = param3(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(1232, self);
+        varargout{1} = yarpMEX(1218, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(1233, self, varargin{1});
+        yarpMEX(1219, self, varargin{1});
       end
     end
     function varargout = param4(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(1234, self);
+        varargout{1} = yarpMEX(1220, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(1235, self, varargin{1});
+        yarpMEX(1221, self, varargin{1});
       end
     end
     function varargout = param5(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(1236, self);
+        varargout{1} = yarpMEX(1222, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(1237, self, varargin{1});
+        yarpMEX(1223, self, varargin{1});
       end
     end
     function varargout = paramZero(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(1238, self);
+        varargout{1} = yarpMEX(1224, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(1239, self, varargin{1});
+        yarpMEX(1225, self, varargin{1});
       end
     end
     function self = CalibrationParameters(varargin)
@@ -81,14 +81,14 @@ classdef CalibrationParameters < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(1240, varargin{:});
+        tmp = yarpMEX(1226, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1241, self);
+        yarpMEX(1227, self);
         self.SwigClear();
       end
     end

--- a/matlab/autogenerated/+yarp/CameraDescriptor.m
+++ b/matlab/autogenerated/+yarp/CameraDescriptor.m
@@ -9,20 +9,20 @@ classdef CameraDescriptor < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(1127, self);
+        varargout{1} = yarpMEX(1113, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(1128, self, varargin{1});
+        yarpMEX(1114, self, varargin{1});
       end
     end
     function varargout = deviceDescription(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(1129, self);
+        varargout{1} = yarpMEX(1115, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(1130, self, varargin{1});
+        yarpMEX(1116, self, varargin{1});
       end
     end
     function self = CameraDescriptor(varargin)
@@ -31,14 +31,14 @@ classdef CameraDescriptor < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(1131, varargin{:});
+        tmp = yarpMEX(1117, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1132, self);
+        yarpMEX(1118, self);
         self.SwigClear();
       end
     end

--- a/matlab/autogenerated/+yarp/CartesianEvent.m
+++ b/matlab/autogenerated/+yarp/CartesianEvent.m
@@ -7,7 +7,7 @@ classdef CartesianEvent < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1349, self);
+        yarpMEX(1335, self);
         self.SwigClear();
       end
     end
@@ -15,26 +15,26 @@ classdef CartesianEvent < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(1350, self);
+        varargout{1} = yarpMEX(1336, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(1351, self, varargin{1});
+        yarpMEX(1337, self, varargin{1});
       end
     end
     function varargout = cartesianEventVariables(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(1352, self);
+        varargout{1} = yarpMEX(1338, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(1353, self, varargin{1});
+        yarpMEX(1339, self, varargin{1});
       end
     end
     function varargout = cartesianEventCallback(self,varargin)
     %Usage: cartesianEventCallback ()
     %
-      [varargout{1:nargout}] = yarpMEX(1354, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1340, self, varargin{:});
     end
     function self = CartesianEvent(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/CartesianEventParameters.m
+++ b/matlab/autogenerated/+yarp/CartesianEventParameters.m
@@ -9,20 +9,20 @@ classdef CartesianEventParameters < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(1335, self);
+        varargout{1} = yarpMEX(1321, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(1336, self, varargin{1});
+        yarpMEX(1322, self, varargin{1});
       end
     end
     function varargout = motionOngoingCheckPoint(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(1337, self);
+        varargout{1} = yarpMEX(1323, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(1338, self, varargin{1});
+        yarpMEX(1324, self, varargin{1});
       end
     end
     function self = CartesianEventParameters(varargin)
@@ -31,14 +31,14 @@ classdef CartesianEventParameters < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(1339, varargin{:});
+        tmp = yarpMEX(1325, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1340, self);
+        yarpMEX(1326, self);
         self.SwigClear();
       end
     end

--- a/matlab/autogenerated/+yarp/CartesianEventVariables.m
+++ b/matlab/autogenerated/+yarp/CartesianEventVariables.m
@@ -9,30 +9,30 @@ classdef CartesianEventVariables < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(1341, self);
+        varargout{1} = yarpMEX(1327, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(1342, self, varargin{1});
+        yarpMEX(1328, self, varargin{1});
       end
     end
     function varargout = time(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(1343, self);
+        varargout{1} = yarpMEX(1329, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(1344, self, varargin{1});
+        yarpMEX(1330, self, varargin{1});
       end
     end
     function varargout = motionOngoingCheckPoint(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(1345, self);
+        varargout{1} = yarpMEX(1331, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(1346, self, varargin{1});
+        yarpMEX(1332, self, varargin{1});
       end
     end
     function self = CartesianEventVariables(varargin)
@@ -41,14 +41,14 @@ classdef CartesianEventVariables < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(1347, varargin{:});
+        tmp = yarpMEX(1333, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1348, self);
+        yarpMEX(1334, self);
         self.SwigClear();
       end
     end

--- a/matlab/autogenerated/+yarp/ConnectionReader.m
+++ b/matlab/autogenerated/+yarp/ConnectionReader.m
@@ -7,170 +7,170 @@ classdef ConnectionReader < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(58, self);
+        yarpMEX(46, self);
         self.SwigClear();
       end
     end
     function varargout = expectBlock(self,varargin)
     %Usage: retval = expectBlock (data, len)
     %
-    %data is of type char const *. len is of type size_t. data is of type char const *. len is of type size_t. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(59, self, varargin{:});
+    %data is of type char *. len is of type size_t. data is of type char *. len is of type size_t. retval is of type bool. 
+      [varargout{1:nargout}] = yarpMEX(47, self, varargin{:});
     end
     function varargout = expectText(self,varargin)
     %Usage: retval = expectText ()
     %
     %retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(60, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(48, self, varargin{:});
     end
     function varargout = expectInt(self,varargin)
     %Usage: retval = expectInt ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(61, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(49, self, varargin{:});
     end
     function varargout = expectInt8(self,varargin)
     %Usage: retval = expectInt8 ()
     %
     %retval is of type std::int8_t. 
-      [varargout{1:nargout}] = yarpMEX(62, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(50, self, varargin{:});
     end
     function varargout = expectInt16(self,varargin)
     %Usage: retval = expectInt16 ()
     %
     %retval is of type std::int16_t. 
-      [varargout{1:nargout}] = yarpMEX(63, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(51, self, varargin{:});
     end
     function varargout = expectInt32(self,varargin)
     %Usage: retval = expectInt32 ()
     %
     %retval is of type std::int32_t. 
-      [varargout{1:nargout}] = yarpMEX(64, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(52, self, varargin{:});
     end
     function varargout = expectInt64(self,varargin)
     %Usage: retval = expectInt64 ()
     %
     %retval is of type std::int64_t. 
-      [varargout{1:nargout}] = yarpMEX(65, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(53, self, varargin{:});
     end
     function varargout = expectDouble(self,varargin)
     %Usage: retval = expectDouble ()
     %
     %retval is of type double. 
-      [varargout{1:nargout}] = yarpMEX(66, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(54, self, varargin{:});
     end
     function varargout = expectFloat32(self,varargin)
     %Usage: retval = expectFloat32 ()
     %
     %retval is of type yarp::conf::float32_t. 
-      [varargout{1:nargout}] = yarpMEX(67, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(55, self, varargin{:});
     end
     function varargout = expectFloat64(self,varargin)
     %Usage: retval = expectFloat64 ()
     %
     %retval is of type yarp::conf::float64_t. 
-      [varargout{1:nargout}] = yarpMEX(68, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(56, self, varargin{:});
     end
     function varargout = isTextMode(self,varargin)
     %Usage: retval = isTextMode ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(69, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(57, self, varargin{:});
     end
     function varargout = isBareMode(self,varargin)
     %Usage: retval = isBareMode ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(70, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(58, self, varargin{:});
     end
     function varargout = convertTextMode(self,varargin)
     %Usage: retval = convertTextMode ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(71, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(59, self, varargin{:});
     end
     function varargout = getSize(self,varargin)
     %Usage: retval = getSize ()
     %
     %retval is of type size_t. 
-      [varargout{1:nargout}] = yarpMEX(72, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(60, self, varargin{:});
     end
     function varargout = getWriter(self,varargin)
     %Usage: retval = getWriter ()
     %
     %retval is of type ConnectionWriter. 
-      [varargout{1:nargout}] = yarpMEX(73, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(61, self, varargin{:});
     end
     function varargout = readEnvelope(self,varargin)
     %Usage: retval = readEnvelope ()
     %
     %retval is of type Bytes. 
-      [varargout{1:nargout}] = yarpMEX(74, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(62, self, varargin{:});
     end
     function varargout = getReference(self,varargin)
     %Usage: retval = getReference ()
     %
     %retval is of type Portable. 
-      [varargout{1:nargout}] = yarpMEX(75, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(63, self, varargin{:});
     end
     function varargout = getRemoteContact(self,varargin)
     %Usage: retval = getRemoteContact ()
     %
     %retval is of type Contact. 
-      [varargout{1:nargout}] = yarpMEX(76, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(64, self, varargin{:});
     end
     function varargout = getLocalContact(self,varargin)
     %Usage: retval = getLocalContact ()
     %
     %retval is of type Contact. 
-      [varargout{1:nargout}] = yarpMEX(77, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(65, self, varargin{:});
     end
     function varargout = isValid(self,varargin)
     %Usage: retval = isValid ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(78, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(66, self, varargin{:});
     end
     function varargout = isActive(self,varargin)
     %Usage: retval = isActive ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(79, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(67, self, varargin{:});
     end
     function varargout = isError(self,varargin)
     %Usage: retval = isError ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(80, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(68, self, varargin{:});
     end
     function varargout = requestDrop(self,varargin)
     %Usage: requestDrop ()
     %
-      [varargout{1:nargout}] = yarpMEX(81, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(69, self, varargin{:});
     end
     function varargout = getConnectionModifiers(self,varargin)
     %Usage: retval = getConnectionModifiers ()
     %
     %retval is of type Searchable. 
-      [varargout{1:nargout}] = yarpMEX(82, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(70, self, varargin{:});
     end
     function varargout = pushInt(self,varargin)
     %Usage: retval = pushInt (x)
     %
     %x is of type int. x is of type int. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(83, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(71, self, varargin{:});
     end
     function varargout = setSize(self,varargin)
     %Usage: retval = setSize (len)
     %
     %len is of type size_t. len is of type size_t. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(84, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(72, self, varargin{:});
     end
     function varargout = setParentConnectionReader(self,varargin)
     %Usage: setParentConnectionReader (parentConnectionReader)
     %
     %parentConnectionReader is of type ConnectionReader. 
-      [varargout{1:nargout}] = yarpMEX(87, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(75, self, varargin{:});
     end
     function self = ConnectionReader(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -187,13 +187,13 @@ classdef ConnectionReader < SwigRef
     %Usage: retval = createConnectionReader (is)
     %
     %is is of type yarp::os::InputStream &. is is of type yarp::os::InputStream &. retval is of type ConnectionReader. 
-     [varargout{1:nargout}] = yarpMEX(85, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(73, varargin{:});
     end
     function varargout = readFromStream(varargin)
     %Usage: retval = readFromStream (portable, is)
     %
     %portable is of type PortReader. is is of type yarp::os::InputStream &. portable is of type PortReader. is is of type yarp::os::InputStream &. retval is of type bool. 
-     [varargout{1:nargout}] = yarpMEX(86, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(74, varargin{:});
     end
   end
 end

--- a/matlab/autogenerated/+yarp/ConnectionWriter.m
+++ b/matlab/autogenerated/+yarp/ConnectionWriter.m
@@ -7,7 +7,7 @@ classdef ConnectionWriter < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(88, self);
+        yarpMEX(76, self);
         self.SwigClear();
       end
     end
@@ -15,144 +15,144 @@ classdef ConnectionWriter < SwigRef
     %Usage: appendBlock (data, len)
     %
     %data is of type char const *. len is of type size_t. 
-      [varargout{1:nargout}] = yarpMEX(89, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(77, self, varargin{:});
     end
     function varargout = appendInt(self,varargin)
     %Usage: appendInt (data)
     %
     %data is of type int. 
-      [varargout{1:nargout}] = yarpMEX(90, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(78, self, varargin{:});
     end
     function varargout = appendInt8(self,varargin)
     %Usage: appendInt8 (data)
     %
     %data is of type std::int8_t. 
-      [varargout{1:nargout}] = yarpMEX(91, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(79, self, varargin{:});
     end
     function varargout = appendInt16(self,varargin)
     %Usage: appendInt16 (data)
     %
     %data is of type std::int16_t. 
-      [varargout{1:nargout}] = yarpMEX(92, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(80, self, varargin{:});
     end
     function varargout = appendInt32(self,varargin)
     %Usage: appendInt32 (data)
     %
     %data is of type std::int32_t. 
-      [varargout{1:nargout}] = yarpMEX(93, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(81, self, varargin{:});
     end
     function varargout = appendInt64(self,varargin)
     %Usage: appendInt64 (data)
     %
     %data is of type std::int64_t. 
-      [varargout{1:nargout}] = yarpMEX(94, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(82, self, varargin{:});
     end
     function varargout = appendDouble(self,varargin)
     %Usage: appendDouble (data)
     %
     %data is of type double. 
-      [varargout{1:nargout}] = yarpMEX(95, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(83, self, varargin{:});
     end
     function varargout = appendFloat32(self,varargin)
     %Usage: appendFloat32 (data)
     %
     %data is of type yarp::conf::float32_t. 
-      [varargout{1:nargout}] = yarpMEX(96, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(84, self, varargin{:});
     end
     function varargout = appendFloat64(self,varargin)
     %Usage: appendFloat64 (data)
     %
     %data is of type yarp::conf::float64_t. 
-      [varargout{1:nargout}] = yarpMEX(97, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(85, self, varargin{:});
     end
     function varargout = appendString(self,varargin)
     %Usage: appendString (str)
     %
     %str is of type char const *. 
-      [varargout{1:nargout}] = yarpMEX(98, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(86, self, varargin{:});
     end
     function varargout = appendExternalBlock(self,varargin)
     %Usage: appendExternalBlock (data, len)
     %
     %data is of type char const *. len is of type size_t. 
-      [varargout{1:nargout}] = yarpMEX(99, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(87, self, varargin{:});
     end
     function varargout = isTextMode(self,varargin)
     %Usage: retval = isTextMode ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(100, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(88, self, varargin{:});
     end
     function varargout = isBareMode(self,varargin)
     %Usage: retval = isBareMode ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(101, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(89, self, varargin{:});
     end
     function varargout = declareSizes(self,varargin)
     %Usage: declareSizes (argc, argv)
     %
     %argc is of type int. argv is of type int *. 
-      [varargout{1:nargout}] = yarpMEX(102, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(90, self, varargin{:});
     end
     function varargout = setReplyHandler(self,varargin)
     %Usage: setReplyHandler (reader)
     %
     %reader is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(103, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(91, self, varargin{:});
     end
     function varargout = setReference(self,varargin)
     %Usage: setReference (obj)
     %
     %obj is of type Portable. 
-      [varargout{1:nargout}] = yarpMEX(104, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(92, self, varargin{:});
     end
     function varargout = convertTextMode(self,varargin)
     %Usage: retval = convertTextMode ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(105, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(93, self, varargin{:});
     end
     function varargout = isValid(self,varargin)
     %Usage: retval = isValid ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(106, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(94, self, varargin{:});
     end
     function varargout = isActive(self,varargin)
     %Usage: retval = isActive ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(107, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(95, self, varargin{:});
     end
     function varargout = isError(self,varargin)
     %Usage: retval = isError ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(108, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(96, self, varargin{:});
     end
     function varargout = requestDrop(self,varargin)
     %Usage: requestDrop ()
     %
-      [varargout{1:nargout}] = yarpMEX(109, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(97, self, varargin{:});
     end
     function varargout = isNull(self,varargin)
     %Usage: retval = isNull ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(110, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(98, self, varargin{:});
     end
     function varargout = getBuffer(self,varargin)
     %Usage: retval = getBuffer ()
     %
     %retval is of type yarp::os::SizedWriter *. 
-      [varargout{1:nargout}] = yarpMEX(111, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(99, self, varargin{:});
     end
     function varargout = appendRawString(self,varargin)
     %Usage: appendRawString (str)
     %
     %str is of type std::string const &. 
-      [varargout{1:nargout}] = yarpMEX(112, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(100, self, varargin{:});
     end
     function self = ConnectionWriter(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -169,13 +169,13 @@ classdef ConnectionWriter < SwigRef
     %Usage: retval = createBufferedConnectionWriter ()
     %
     %retval is of type ConnectionWriter. 
-     [varargout{1:nargout}] = yarpMEX(113, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(101, varargin{:});
     end
     function varargout = writeToStream(varargin)
     %Usage: retval = writeToStream (portable, os)
     %
     %portable is of type PortWriter. os is of type yarp::os::OutputStream &. portable is of type PortWriter. os is of type yarp::os::OutputStream &. retval is of type bool. 
-     [varargout{1:nargout}] = yarpMEX(114, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(102, varargin{:});
     end
   end
 end

--- a/matlab/autogenerated/+yarp/Contact.m
+++ b/matlab/autogenerated/+yarp/Contact.m
@@ -130,42 +130,6 @@ classdef Contact < SwigRef
     %retval is of type std::string. 
       [varargout{1:nargout}] = yarpMEX(44, self, varargin{:});
     end
-    function varargout = addName(self,varargin)
-    %Usage: retval = addName (name)
-    %
-    %name is of type std::string const &. name is of type std::string const &. retval is of type Contact. 
-      [varargout{1:nargout}] = yarpMEX(46, self, varargin{:});
-    end
-    function varargout = addCarrier(self,varargin)
-    %Usage: retval = addCarrier (carrier)
-    %
-    %carrier is of type std::string const &. carrier is of type std::string const &. retval is of type Contact. 
-      [varargout{1:nargout}] = yarpMEX(47, self, varargin{:});
-    end
-    function varargout = addHost(self,varargin)
-    %Usage: retval = addHost (hostname)
-    %
-    %hostname is of type std::string const &. hostname is of type std::string const &. retval is of type Contact. 
-      [varargout{1:nargout}] = yarpMEX(48, self, varargin{:});
-    end
-    function varargout = addPort(self,varargin)
-    %Usage: retval = addPort (port)
-    %
-    %port is of type int. port is of type int. retval is of type Contact. 
-      [varargout{1:nargout}] = yarpMEX(49, self, varargin{:});
-    end
-    function varargout = addNested(self,varargin)
-    %Usage: retval = addNested (nestedContact)
-    %
-    %nestedContact is of type NestedContact const &. nestedContact is of type NestedContact const &. retval is of type Contact. 
-      [varargout{1:nargout}] = yarpMEX(50, self, varargin{:});
-    end
-    function varargout = addSocket(self,varargin)
-    %Usage: retval = addSocket (carrier, hostname, port)
-    %
-    %carrier is of type std::string const &. hostname is of type std::string const &. port is of type int. carrier is of type std::string const &. hostname is of type std::string const &. port is of type int. retval is of type Contact. 
-      [varargout{1:nargout}] = yarpMEX(51, self, varargin{:});
-    end
   end
   methods(Static)
     function varargout = fromConfig(varargin)
@@ -185,42 +149,6 @@ classdef Contact < SwigRef
     %
     %name is of type char const *. name is of type char const *. retval is of type std::string. 
      [varargout{1:nargout}] = yarpMEX(45, varargin{:});
-    end
-    function varargout = empty(varargin)
-    %Usage: retval = empty ()
-    %
-    %retval is of type Contact. 
-     [varargout{1:nargout}] = yarpMEX(52, varargin{:});
-    end
-    function varargout = invalid(varargin)
-    %Usage: retval = invalid ()
-    %
-    %retval is of type Contact. 
-     [varargout{1:nargout}] = yarpMEX(53, varargin{:});
-    end
-    function varargout = byName(varargin)
-    %Usage: retval = byName (name)
-    %
-    %name is of type std::string const &. name is of type std::string const &. retval is of type Contact. 
-     [varargout{1:nargout}] = yarpMEX(54, varargin{:});
-    end
-    function varargout = byCarrier(varargin)
-    %Usage: retval = byCarrier (carrier)
-    %
-    %carrier is of type std::string const &. carrier is of type std::string const &. retval is of type Contact. 
-     [varargout{1:nargout}] = yarpMEX(55, varargin{:});
-    end
-    function varargout = bySocket(varargin)
-    %Usage: retval = bySocket (carrier, hostname, port)
-    %
-    %carrier is of type std::string const &. hostname is of type std::string const &. port is of type int. carrier is of type std::string const &. hostname is of type std::string const &. port is of type int. retval is of type Contact. 
-     [varargout{1:nargout}] = yarpMEX(56, varargin{:});
-    end
-    function varargout = byConfig(varargin)
-    %Usage: retval = byConfig (config)
-    %
-    %config is of type Searchable. config is of type Searchable. retval is of type Contact. 
-     [varargout{1:nargout}] = yarpMEX(57, varargin{:});
     end
   end
 end

--- a/matlab/autogenerated/+yarp/ContactStyle.m
+++ b/matlab/autogenerated/+yarp/ContactStyle.m
@@ -9,13 +9,73 @@ classdef ContactStyle < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
+        varargout{1} = yarpMEX(593, self);
+      else
+        nargoutchk(0, 0)
+        yarpMEX(594, self, varargin{1});
+      end
+    end
+    function varargout = quiet(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = yarpMEX(595, self);
+      else
+        nargoutchk(0, 0)
+        yarpMEX(596, self, varargin{1});
+      end
+    end
+    function varargout = verboseOnSuccess(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = yarpMEX(597, self);
+      else
+        nargoutchk(0, 0)
+        yarpMEX(598, self, varargin{1});
+      end
+    end
+    function varargout = timeout(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = yarpMEX(599, self);
+      else
+        nargoutchk(0, 0)
+        yarpMEX(600, self, varargin{1});
+      end
+    end
+    function varargout = carrier(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = yarpMEX(601, self);
+      else
+        nargoutchk(0, 0)
+        yarpMEX(602, self, varargin{1});
+      end
+    end
+    function varargout = expectReply(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = yarpMEX(603, self);
+      else
+        nargoutchk(0, 0)
+        yarpMEX(604, self, varargin{1});
+      end
+    end
+    function varargout = persistent1(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
         varargout{1} = yarpMEX(605, self);
       else
         nargoutchk(0, 0)
         yarpMEX(606, self, varargin{1});
       end
     end
-    function varargout = quiet(self, varargin)
+    function varargout = persistenceType(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -25,80 +85,20 @@ classdef ContactStyle < SwigRef
         yarpMEX(608, self, varargin{1});
       end
     end
-    function varargout = verboseOnSuccess(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = yarpMEX(609, self);
-      else
-        nargoutchk(0, 0)
-        yarpMEX(610, self, varargin{1});
-      end
-    end
-    function varargout = timeout(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = yarpMEX(611, self);
-      else
-        nargoutchk(0, 0)
-        yarpMEX(612, self, varargin{1});
-      end
-    end
-    function varargout = carrier(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = yarpMEX(613, self);
-      else
-        nargoutchk(0, 0)
-        yarpMEX(614, self, varargin{1});
-      end
-    end
-    function varargout = expectReply(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = yarpMEX(615, self);
-      else
-        nargoutchk(0, 0)
-        yarpMEX(616, self, varargin{1});
-      end
-    end
-    function varargout = persistent1(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = yarpMEX(617, self);
-      else
-        nargoutchk(0, 0)
-        yarpMEX(618, self, varargin{1});
-      end
-    end
-    function varargout = persistenceType(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = yarpMEX(619, self);
-      else
-        nargoutchk(0, 0)
-        yarpMEX(620, self, varargin{1});
-      end
-    end
     function self = ContactStyle(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(621, varargin{:});
+        tmp = yarpMEX(609, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(622, self);
+        yarpMEX(610, self);
         self.SwigClear();
       end
     end

--- a/matlab/autogenerated/+yarp/Contactable.m
+++ b/matlab/autogenerated/+yarp/Contactable.m
@@ -7,7 +7,7 @@ classdef Contactable < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(219, self);
+        yarpMEX(207, self);
         self.SwigClear();
       end
     end
@@ -15,196 +15,196 @@ classdef Contactable < SwigRef
     %Usage: retval = open (contact)
     %
     %contact is of type Contact. contact is of type Contact. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(220, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(208, self, varargin{:});
     end
     function varargout = addOutput(self,varargin)
     %Usage: retval = addOutput (contact)
     %
     %contact is of type Contact. contact is of type Contact. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(221, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(209, self, varargin{:});
     end
     function varargout = close(self,varargin)
     %Usage: close ()
     %
-      [varargout{1:nargout}] = yarpMEX(222, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(210, self, varargin{:});
     end
     function varargout = interrupt(self,varargin)
     %Usage: interrupt ()
     %
-      [varargout{1:nargout}] = yarpMEX(223, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(211, self, varargin{:});
     end
     function varargout = resume(self,varargin)
     %Usage: resume ()
     %
-      [varargout{1:nargout}] = yarpMEX(224, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(212, self, varargin{:});
     end
     function varargout = where(self,varargin)
     %Usage: retval = where ()
     %
     %retval is of type Contact. 
-      [varargout{1:nargout}] = yarpMEX(225, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(213, self, varargin{:});
     end
     function varargout = getName(self,varargin)
     %Usage: retval = getName ()
     %
     %retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(226, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(214, self, varargin{:});
     end
     function varargout = getEnvelope(self,varargin)
     %Usage: retval = getEnvelope (envelope)
     %
     %envelope is of type PortReader. envelope is of type PortReader. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(227, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(215, self, varargin{:});
     end
     function varargout = getInputCount(self,varargin)
     %Usage: retval = getInputCount ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(228, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(216, self, varargin{:});
     end
     function varargout = getOutputCount(self,varargin)
     %Usage: retval = getOutputCount ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(229, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(217, self, varargin{:});
     end
     function varargout = getReport(self,varargin)
     %Usage: getReport (reporter)
     %
     %reporter is of type PortReport. 
-      [varargout{1:nargout}] = yarpMEX(230, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(218, self, varargin{:});
     end
     function varargout = setReporter(self,varargin)
     %Usage: setReporter (reporter)
     %
     %reporter is of type PortReport. 
-      [varargout{1:nargout}] = yarpMEX(231, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(219, self, varargin{:});
     end
     function varargout = resetReporter(self,varargin)
     %Usage: resetReporter ()
     %
-      [varargout{1:nargout}] = yarpMEX(232, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(220, self, varargin{:});
     end
     function varargout = isWriting(self,varargin)
     %Usage: retval = isWriting ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(233, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(221, self, varargin{:});
     end
     function varargout = setReader(self,varargin)
     %Usage: setReader (reader)
     %
     %reader is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(234, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(222, self, varargin{:});
     end
     function varargout = setAdminReader(self,varargin)
     %Usage: setAdminReader (reader)
     %
     %reader is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(235, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(223, self, varargin{:});
     end
     function varargout = setInputMode(self,varargin)
     %Usage: setInputMode (expectInput)
     %
     %expectInput is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(236, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(224, self, varargin{:});
     end
     function varargout = setOutputMode(self,varargin)
     %Usage: setOutputMode (expectOutput)
     %
     %expectOutput is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(237, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(225, self, varargin{:});
     end
     function varargout = setRpcMode(self,varargin)
     %Usage: setRpcMode (expectRpc)
     %
     %expectRpc is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(238, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(226, self, varargin{:});
     end
     function varargout = getType(self,varargin)
     %Usage: retval = getType ()
     %
-    %retval is of type Type. 
-      [varargout{1:nargout}] = yarpMEX(239, self, varargin{:});
+    %retval is of type yarp::os::Type. 
+      [varargout{1:nargout}] = yarpMEX(227, self, varargin{:});
     end
     function varargout = promiseType(self,varargin)
     %Usage: promiseType (typ)
     %
-    %typ is of type Type const &. 
-      [varargout{1:nargout}] = yarpMEX(240, self, varargin{:});
+    %typ is of type yarp::os::Type const &. 
+      [varargout{1:nargout}] = yarpMEX(228, self, varargin{:});
     end
     function varargout = acquireProperties(self,varargin)
     %Usage: retval = acquireProperties (readOnly)
     %
     %readOnly is of type bool. readOnly is of type bool. retval is of type Property. 
-      [varargout{1:nargout}] = yarpMEX(241, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(229, self, varargin{:});
     end
     function varargout = releaseProperties(self,varargin)
     %Usage: releaseProperties (prop)
     %
     %prop is of type Property. 
-      [varargout{1:nargout}] = yarpMEX(242, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(230, self, varargin{:});
     end
     function varargout = includeNodeInName(self,varargin)
     %Usage: includeNodeInName (flag)
     %
     %flag is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(243, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(231, self, varargin{:});
     end
     function varargout = setReadOnly(self,varargin)
     %Usage: setReadOnly ()
     %
-      [varargout{1:nargout}] = yarpMEX(244, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(232, self, varargin{:});
     end
     function varargout = setWriteOnly(self,varargin)
     %Usage: setWriteOnly ()
     %
-      [varargout{1:nargout}] = yarpMEX(245, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(233, self, varargin{:});
     end
     function varargout = setRpcServer(self,varargin)
     %Usage: setRpcServer ()
     %
-      [varargout{1:nargout}] = yarpMEX(246, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(234, self, varargin{:});
     end
     function varargout = setRpcClient(self,varargin)
     %Usage: setRpcClient ()
     %
-      [varargout{1:nargout}] = yarpMEX(247, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(235, self, varargin{:});
     end
     function varargout = setCallbackLock(self,varargin)
     %Usage: retval = setCallbackLock ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(248, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(236, self, varargin{:});
     end
     function varargout = removeCallbackLock(self,varargin)
     %Usage: retval = removeCallbackLock ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(249, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(237, self, varargin{:});
     end
     function varargout = lockCallback(self,varargin)
     %Usage: retval = lockCallback ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(250, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(238, self, varargin{:});
     end
     function varargout = tryLockCallback(self,varargin)
     %Usage: retval = tryLockCallback ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(251, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(239, self, varargin{:});
     end
     function varargout = unlockCallback(self,varargin)
     %Usage: unlockCallback ()
     %
-      [varargout{1:nargout}] = yarpMEX(252, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(240, self, varargin{:});
     end
     function varargout = setEnvelope(self,varargin)
     %Usage: retval = setEnvelope (data)
     %
     %data is of type Portable. data is of type Portable. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(253, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(241, self, varargin{:});
     end
     function self = Contactable(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/DVector.m
+++ b/matlab/autogenerated/+yarp/DVector.m
@@ -9,89 +9,89 @@ classdef DVector < SwigRef
     %Usage: retval = pop ()
     %
     %retval is of type std::vector< double >::value_type. 
-      [varargout{1:nargout}] = yarpMEX(1787, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1773, self, varargin{:});
     end
     function varargout = brace(self,varargin)
     %Usage: retval = brace (i)
     %
     %i is of type std::vector< double >::difference_type. i is of type std::vector< double >::difference_type. retval is of type std::vector< double >::value_type. 
-      [varargout{1:nargout}] = yarpMEX(1788, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1774, self, varargin{:});
     end
     function varargout = setbrace(self,varargin)
     %Usage: setbrace (x, i)
     %
     %x is of type std::vector< double >::value_type. i is of type std::vector< double >::difference_type. 
-      [varargout{1:nargout}] = yarpMEX(1789, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1775, self, varargin{:});
     end
     function varargout = append(self,varargin)
     %Usage: append (x)
     %
     %x is of type std::vector< double >::value_type. 
-      [varargout{1:nargout}] = yarpMEX(1790, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1776, self, varargin{:});
     end
     function varargout = empty(self,varargin)
     %Usage: retval = empty ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1791, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1777, self, varargin{:});
     end
     function varargout = size(self,varargin)
     %Usage: retval = size ()
     %
     %retval is of type std::vector< double >::size_type. 
-      [varargout{1:nargout}] = yarpMEX(1792, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1778, self, varargin{:});
     end
     function varargout = swap(self,varargin)
     %Usage: swap (v)
     %
     %v is of type DVector. 
-      [varargout{1:nargout}] = yarpMEX(1793, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1779, self, varargin{:});
     end
     function varargout = begin(self,varargin)
     %Usage: retval = begin ()
     %
     %retval is of type std::vector< double >::iterator. 
-      [varargout{1:nargout}] = yarpMEX(1794, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1780, self, varargin{:});
     end
     function varargout = end(self,varargin)
     %Usage: retval = end ()
     %
     %retval is of type std::vector< double >::iterator. 
-      [varargout{1:nargout}] = yarpMEX(1795, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1781, self, varargin{:});
     end
     function varargout = rbegin(self,varargin)
     %Usage: retval = rbegin ()
     %
     %retval is of type std::vector< double >::reverse_iterator. 
-      [varargout{1:nargout}] = yarpMEX(1796, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1782, self, varargin{:});
     end
     function varargout = rend(self,varargin)
     %Usage: retval = rend ()
     %
     %retval is of type std::vector< double >::reverse_iterator. 
-      [varargout{1:nargout}] = yarpMEX(1797, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1783, self, varargin{:});
     end
     function varargout = clear(self,varargin)
     %Usage: clear ()
     %
-      [varargout{1:nargout}] = yarpMEX(1798, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1784, self, varargin{:});
     end
     function varargout = get_allocator(self,varargin)
     %Usage: retval = get_allocator ()
     %
     %retval is of type std::vector< double >::allocator_type. 
-      [varargout{1:nargout}] = yarpMEX(1799, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1785, self, varargin{:});
     end
     function varargout = pop_back(self,varargin)
     %Usage: pop_back ()
     %
-      [varargout{1:nargout}] = yarpMEX(1800, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1786, self, varargin{:});
     end
     function varargout = erase(self,varargin)
     %Usage: retval = erase (first, last)
     %
     %first is of type std::vector< double >::iterator. last is of type std::vector< double >::iterator. first is of type std::vector< double >::iterator. last is of type std::vector< double >::iterator. retval is of type std::vector< double >::iterator. 
-      [varargout{1:nargout}] = yarpMEX(1801, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1787, self, varargin{:});
     end
     function self = DVector(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -99,7 +99,7 @@ classdef DVector < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(1802, varargin{:});
+        tmp = yarpMEX(1788, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
@@ -108,53 +108,53 @@ classdef DVector < SwigRef
     %Usage: push_back (x)
     %
     %x is of type std::vector< double >::value_type const &. 
-      [varargout{1:nargout}] = yarpMEX(1803, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1789, self, varargin{:});
     end
     function varargout = front(self,varargin)
     %Usage: retval = front ()
     %
     %retval is of type std::vector< double >::value_type const &. 
-      [varargout{1:nargout}] = yarpMEX(1804, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1790, self, varargin{:});
     end
     function varargout = back(self,varargin)
     %Usage: retval = back ()
     %
     %retval is of type std::vector< double >::value_type const &. 
-      [varargout{1:nargout}] = yarpMEX(1805, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1791, self, varargin{:});
     end
     function varargout = assign(self,varargin)
     %Usage: assign (n, x)
     %
     %n is of type std::vector< double >::size_type. x is of type std::vector< double >::value_type const &. 
-      [varargout{1:nargout}] = yarpMEX(1806, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1792, self, varargin{:});
     end
     function varargout = resize(self,varargin)
     %Usage: resize (new_size, x)
     %
     %new_size is of type std::vector< double >::size_type. x is of type std::vector< double >::value_type const &. 
-      [varargout{1:nargout}] = yarpMEX(1807, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1793, self, varargin{:});
     end
     function varargout = insert(self,varargin)
     %Usage: insert (pos, n, x)
     %
     %pos is of type std::vector< double >::iterator. n is of type std::vector< double >::size_type. x is of type std::vector< double >::value_type const &. 
-      [varargout{1:nargout}] = yarpMEX(1808, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1794, self, varargin{:});
     end
     function varargout = reserve(self,varargin)
     %Usage: reserve (n)
     %
     %n is of type std::vector< double >::size_type. 
-      [varargout{1:nargout}] = yarpMEX(1809, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1795, self, varargin{:});
     end
     function varargout = capacity(self,varargin)
     %Usage: retval = capacity ()
     %
     %retval is of type std::vector< double >::size_type. 
-      [varargout{1:nargout}] = yarpMEX(1810, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1796, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1811, self);
+        yarpMEX(1797, self);
         self.SwigClear();
       end
     end

--- a/matlab/autogenerated/+yarp/DeprecatedDeviceDriver.m
+++ b/matlab/autogenerated/+yarp/DeprecatedDeviceDriver.m
@@ -1,11 +1,9 @@
-classdef DeprecatedDeviceDriver < SwigRef
+classdef DeprecatedDeviceDriver < yarp.DeviceDriver
     %Usage: DeprecatedDeviceDriver ()
     %
   methods
-    function this = swig_this(self)
-      this = yarpMEX(3, self);
-    end
     function self = DeprecatedDeviceDriver(varargin)
+      self@yarp.DeviceDriver(SwigRef.Null);
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;

--- a/matlab/autogenerated/+yarp/DeprecatedDeviceDriver.m
+++ b/matlab/autogenerated/+yarp/DeprecatedDeviceDriver.m
@@ -9,14 +9,14 @@ classdef DeprecatedDeviceDriver < yarp.DeviceDriver
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(1059, varargin{:});
+        tmp = yarpMEX(1045, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1060, self);
+        yarpMEX(1046, self);
         self.SwigClear();
       end
     end

--- a/matlab/autogenerated/+yarp/DeviceDriver.m
+++ b/matlab/autogenerated/+yarp/DeviceDriver.m
@@ -1,10 +1,7 @@
-classdef DeviceDriver < SwigRef
+classdef DeviceDriver < yarp.IConfig
     %Usage: DeviceDriver ()
     %
   methods
-    function this = swig_this(self)
-      this = yarpMEX(3, self);
-    end
     function delete(self)
       if self.swigPtr
         yarpMEX(1054, self);
@@ -30,6 +27,7 @@ classdef DeviceDriver < SwigRef
       [varargout{1:nargout}] = yarpMEX(1057, self, varargin{:});
     end
     function self = DeviceDriver(varargin)
+      self@yarp.IConfig(SwigRef.Null);
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;

--- a/matlab/autogenerated/+yarp/DeviceDriver.m
+++ b/matlab/autogenerated/+yarp/DeviceDriver.m
@@ -4,7 +4,7 @@ classdef DeviceDriver < yarp.IConfig
   methods
     function delete(self)
       if self.swigPtr
-        yarpMEX(1054, self);
+        yarpMEX(1040, self);
         self.SwigClear();
       end
     end
@@ -12,19 +12,19 @@ classdef DeviceDriver < yarp.IConfig
     %Usage: retval = open (config)
     %
     %config is of type Searchable. config is of type Searchable. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1055, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1041, self, varargin{:});
     end
     function varargout = close(self,varargin)
     %Usage: retval = close ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1056, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1042, self, varargin{:});
     end
     function varargout = getImplementation(self,varargin)
     %Usage: retval = getImplementation ()
     %
     %retval is of type DeviceDriver. 
-      [varargout{1:nargout}] = yarpMEX(1057, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1043, self, varargin{:});
     end
     function self = DeviceDriver(varargin)
       self@yarp.IConfig(SwigRef.Null);
@@ -33,7 +33,7 @@ classdef DeviceDriver < yarp.IConfig
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(1058, varargin{:});
+        tmp = yarpMEX(1044, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end

--- a/matlab/autogenerated/+yarp/DeviceResponder.m
+++ b/matlab/autogenerated/+yarp/DeviceResponder.m
@@ -13,7 +13,7 @@ classdef DeviceResponder < yarp.PortReader & yarp.BottleCallback
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(1061, varargin{:});
+        tmp = yarpMEX(1047, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
@@ -22,40 +22,40 @@ classdef DeviceResponder < yarp.PortReader & yarp.BottleCallback
     %Usage: addUsage (bot)
     %
     %bot is of type Bottle. 
-      [varargout{1:nargout}] = yarpMEX(1062, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1048, self, varargin{:});
     end
     function varargout = respond(self,varargin)
     %Usage: retval = respond (command, reply)
     %
     %command is of type Bottle. reply is of type Bottle. command is of type Bottle. reply is of type Bottle. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1063, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1049, self, varargin{:});
     end
     function varargout = read(self,varargin)
     %Usage: retval = read (connection)
     %
     %connection is of type ConnectionReader. connection is of type ConnectionReader. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1064, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1050, self, varargin{:});
     end
     function varargout = onRead(self,varargin)
     %Usage: onRead (v)
     %
     %v is of type Bottle. 
-      [varargout{1:nargout}] = yarpMEX(1065, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1051, self, varargin{:});
     end
     function varargout = makeUsage(self,varargin)
     %Usage: makeUsage ()
     %
-      [varargout{1:nargout}] = yarpMEX(1066, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1052, self, varargin{:});
     end
     function varargout = attach(self,varargin)
     %Usage: attach (source)
     %
     %source is of type TypedReaderBottle. 
-      [varargout{1:nargout}] = yarpMEX(1067, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1053, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1068, self);
+        yarpMEX(1054, self);
         self.SwigClear();
       end
     end

--- a/matlab/autogenerated/+yarp/DeviceResponder.m
+++ b/matlab/autogenerated/+yarp/DeviceResponder.m
@@ -1,4 +1,4 @@
-classdef DeviceResponder < SwigRef
+classdef DeviceResponder < yarp.PortReader & yarp.BottleCallback
     %Usage: DeviceResponder ()
     %
   methods
@@ -6,6 +6,8 @@ classdef DeviceResponder < SwigRef
       this = yarpMEX(3, self);
     end
     function self = DeviceResponder(varargin)
+      self@yarp.PortReader(SwigRef.Null);
+      self@yarp.BottleCallback(SwigRef.Null);
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;

--- a/matlab/autogenerated/+yarp/DriverCreator.m
+++ b/matlab/autogenerated/+yarp/DriverCreator.m
@@ -7,45 +7,45 @@ classdef DriverCreator < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1105, self);
+        yarpMEX(1091, self);
         self.SwigClear();
       end
     end
-    function varargout = toString(self,varargin)
-    %Usage: retval = toString ()
+    function varargout = toString_c(self,varargin)
+    %Usage: retval = toString_c ()
     %
     %retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(1106, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1092, self, varargin{:});
     end
     function varargout = create(self,varargin)
     %Usage: retval = create ()
     %
     %retval is of type DeviceDriver. 
-      [varargout{1:nargout}] = yarpMEX(1107, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1093, self, varargin{:});
     end
     function varargout = getName(self,varargin)
     %Usage: retval = getName ()
     %
     %retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(1108, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1094, self, varargin{:});
     end
     function varargout = getWrapper(self,varargin)
     %Usage: retval = getWrapper ()
     %
     %retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(1109, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1095, self, varargin{:});
     end
     function varargout = getCode(self,varargin)
     %Usage: retval = getCode ()
     %
     %retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(1110, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1096, self, varargin{:});
     end
     function varargout = owner(self,varargin)
     %Usage: retval = owner ()
     %
     %retval is of type PolyDriver. 
-      [varargout{1:nargout}] = yarpMEX(1111, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1097, self, varargin{:});
     end
     function self = DriverCreator(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/Drivers.m
+++ b/matlab/autogenerated/+yarp/Drivers.m
@@ -9,17 +9,17 @@ classdef Drivers < SwigRef
     %Usage: retval = open (config)
     %
     %config is of type Searchable. config is of type Searchable. retval is of type DeviceDriver. 
-      [varargout{1:nargout}] = yarpMEX(1120, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1106, self, varargin{:});
     end
-    function varargout = toString(self,varargin)
-    %Usage: retval = toString ()
+    function varargout = toString_c(self,varargin)
+    %Usage: retval = toString_c ()
     %
     %retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(1121, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1107, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1122, self);
+        yarpMEX(1108, self);
         self.SwigClear();
       end
     end
@@ -27,19 +27,19 @@ classdef Drivers < SwigRef
     %Usage: add (creator)
     %
     %creator is of type DriverCreator. 
-      [varargout{1:nargout}] = yarpMEX(1123, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1109, self, varargin{:});
     end
     function varargout = find(self,varargin)
     %Usage: retval = find (name)
     %
     %name is of type char const *. name is of type char const *. retval is of type DriverCreator. 
-      [varargout{1:nargout}] = yarpMEX(1124, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1110, self, varargin{:});
     end
     function varargout = remove(self,varargin)
     %Usage: retval = remove (name)
     %
     %name is of type char const *. name is of type char const *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1125, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1111, self, varargin{:});
     end
     function self = Drivers(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -56,13 +56,13 @@ classdef Drivers < SwigRef
     %Usage: retval = factory ()
     %
     %retval is of type Drivers. 
-     [varargout{1:nargout}] = yarpMEX(1119, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(1105, varargin{:});
     end
     function varargout = yarpdev(varargin)
     %Usage: retval = yarpdev (argc, argv)
     %
     %argc is of type int. argv is of type char *[]. argc is of type int. argv is of type char *[]. retval is of type int. 
-     [varargout{1:nargout}] = yarpMEX(1126, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(1112, varargin{:});
     end
   end
 end

--- a/matlab/autogenerated/+yarp/DummyConnector.m
+++ b/matlab/autogenerated/+yarp/DummyConnector.m
@@ -11,14 +11,14 @@ classdef DummyConnector < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(674, varargin{:});
+        tmp = yarpMEX(660, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(675, self);
+        yarpMEX(661, self);
         self.SwigClear();
       end
     end
@@ -26,30 +26,30 @@ classdef DummyConnector < SwigRef
     %Usage: setTextMode (textmode)
     %
     %textmode is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(676, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(662, self, varargin{:});
     end
     function varargout = getCleanWriter(self,varargin)
     %Usage: retval = getCleanWriter ()
     %
     %retval is of type ConnectionWriter. 
-      [varargout{1:nargout}] = yarpMEX(677, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(663, self, varargin{:});
     end
     function varargout = getWriter(self,varargin)
     %Usage: retval = getWriter ()
     %
     %retval is of type ConnectionWriter. 
-      [varargout{1:nargout}] = yarpMEX(678, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(664, self, varargin{:});
     end
     function varargout = getReader(self,varargin)
     %Usage: retval = getReader ()
     %
     %retval is of type ConnectionReader. 
-      [varargout{1:nargout}] = yarpMEX(679, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(665, self, varargin{:});
     end
     function varargout = reset(self,varargin)
     %Usage: reset ()
     %
-      [varargout{1:nargout}] = yarpMEX(680, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(666, self, varargin{:});
     end
   end
   methods(Static)

--- a/matlab/autogenerated/+yarp/FlexImage.m
+++ b/matlab/autogenerated/+yarp/FlexImage.m
@@ -6,19 +6,19 @@ classdef FlexImage < yarp.Image
     %Usage: setPixelCode (imgPixelCode)
     %
     %imgPixelCode is of type int. 
-      [varargout{1:nargout}] = yarpMEX(884, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(870, self, varargin{:});
     end
     function varargout = setPixelSize(self,varargin)
     %Usage: setPixelSize (imgPixelSize)
     %
     %imgPixelSize is of type size_t. 
-      [varargout{1:nargout}] = yarpMEX(885, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(871, self, varargin{:});
     end
     function varargout = setQuantum(self,varargin)
     %Usage: setQuantum (imgQuantum)
     %
     %imgQuantum is of type size_t. 
-      [varargout{1:nargout}] = yarpMEX(886, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(872, self, varargin{:});
     end
     function self = FlexImage(varargin)
       self@yarp.Image(SwigRef.Null);
@@ -27,14 +27,14 @@ classdef FlexImage < yarp.Image
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(887, varargin{:});
+        tmp = yarpMEX(873, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(888, self);
+        yarpMEX(874, self);
         self.SwigClear();
       end
     end

--- a/matlab/autogenerated/+yarp/FlexImage.m
+++ b/matlab/autogenerated/+yarp/FlexImage.m
@@ -1,10 +1,7 @@
-classdef FlexImage < SwigRef
+classdef FlexImage < yarp.Image
     %Usage: FlexImage ()
     %
   methods
-    function this = swig_this(self)
-      this = yarpMEX(3, self);
-    end
     function varargout = setPixelCode(self,varargin)
     %Usage: setPixelCode (imgPixelCode)
     %
@@ -24,6 +21,7 @@ classdef FlexImage < SwigRef
       [varargout{1:nargout}] = yarpMEX(886, self, varargin{:});
     end
     function self = FlexImage(varargin)
+      self@yarp.Image(SwigRef.Null);
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;

--- a/matlab/autogenerated/+yarp/GazeEvent.m
+++ b/matlab/autogenerated/+yarp/GazeEvent.m
@@ -7,7 +7,7 @@ classdef GazeEvent < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1414, self);
+        yarpMEX(1400, self);
         self.SwigClear();
       end
     end
@@ -15,26 +15,26 @@ classdef GazeEvent < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(1415, self);
+        varargout{1} = yarpMEX(1401, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(1416, self, varargin{1});
+        yarpMEX(1402, self, varargin{1});
       end
     end
     function varargout = gazeEventVariables(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(1417, self);
+        varargout{1} = yarpMEX(1403, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(1418, self, varargin{1});
+        yarpMEX(1404, self, varargin{1});
       end
     end
     function varargout = gazeEventCallback(self,varargin)
     %Usage: gazeEventCallback ()
     %
-      [varargout{1:nargout}] = yarpMEX(1419, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1405, self, varargin{:});
     end
     function self = GazeEvent(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/GazeEventParameters.m
+++ b/matlab/autogenerated/+yarp/GazeEventParameters.m
@@ -9,20 +9,20 @@ classdef GazeEventParameters < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(1400, self);
+        varargout{1} = yarpMEX(1386, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(1401, self, varargin{1});
+        yarpMEX(1387, self, varargin{1});
       end
     end
     function varargout = motionOngoingCheckPoint(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(1402, self);
+        varargout{1} = yarpMEX(1388, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(1403, self, varargin{1});
+        yarpMEX(1389, self, varargin{1});
       end
     end
     function self = GazeEventParameters(varargin)
@@ -31,14 +31,14 @@ classdef GazeEventParameters < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(1404, varargin{:});
+        tmp = yarpMEX(1390, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1405, self);
+        yarpMEX(1391, self);
         self.SwigClear();
       end
     end

--- a/matlab/autogenerated/+yarp/GazeEventVariables.m
+++ b/matlab/autogenerated/+yarp/GazeEventVariables.m
@@ -9,30 +9,30 @@ classdef GazeEventVariables < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(1406, self);
+        varargout{1} = yarpMEX(1392, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(1407, self, varargin{1});
+        yarpMEX(1393, self, varargin{1});
       end
     end
     function varargout = time(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(1408, self);
+        varargout{1} = yarpMEX(1394, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(1409, self, varargin{1});
+        yarpMEX(1395, self, varargin{1});
       end
     end
     function varargout = motionOngoingCheckPoint(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(1410, self);
+        varargout{1} = yarpMEX(1396, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(1411, self, varargin{1});
+        yarpMEX(1397, self, varargin{1});
       end
     end
     function self = GazeEventVariables(varargin)
@@ -41,14 +41,14 @@ classdef GazeEventVariables < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(1412, varargin{:});
+        tmp = yarpMEX(1398, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1413, self);
+        yarpMEX(1399, self);
         self.SwigClear();
       end
     end

--- a/matlab/autogenerated/+yarp/IAmplifierControl.m
+++ b/matlab/autogenerated/+yarp/IAmplifierControl.m
@@ -7,7 +7,7 @@ classdef IAmplifierControl < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1242, self);
+        yarpMEX(1228, self);
         self.SwigClear();
       end
     end
@@ -15,91 +15,91 @@ classdef IAmplifierControl < SwigRef
     %Usage: retval = enableAmp (j)
     %
     %j is of type int. j is of type int. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1243, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1229, self, varargin{:});
     end
     function varargout = disableAmp(self,varargin)
     %Usage: retval = disableAmp (j)
     %
     %j is of type int. j is of type int. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1244, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1230, self, varargin{:});
     end
     function varargout = getAmpStatus(self,varargin)
     %Usage: retval = getAmpStatus (j, v)
     %
     %j is of type int. v is of type int *. j is of type int. v is of type int *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1245, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1231, self, varargin{:});
     end
     function varargout = getMaxCurrent(self,varargin)
     %Usage: retval = getMaxCurrent (j, v)
     %
     %j is of type int. v is of type double *. j is of type int. v is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1246, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1232, self, varargin{:});
     end
     function varargout = setMaxCurrent(self,varargin)
     %Usage: retval = setMaxCurrent (j, v)
     %
     %j is of type int. v is of type double. j is of type int. v is of type double. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1247, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1233, self, varargin{:});
     end
     function varargout = getNominalCurrent(self,varargin)
     %Usage: retval = getNominalCurrent (m, val)
     %
     %m is of type int. val is of type double *. m is of type int. val is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1248, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1234, self, varargin{:});
     end
     function varargout = setNominalCurrent(self,varargin)
     %Usage: retval = setNominalCurrent (m, val)
     %
     %m is of type int. val is of type double const. m is of type int. val is of type double const. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1249, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1235, self, varargin{:});
     end
     function varargout = getPeakCurrent(self,varargin)
     %Usage: retval = getPeakCurrent (m, val)
     %
     %m is of type int. val is of type double *. m is of type int. val is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1250, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1236, self, varargin{:});
     end
     function varargout = setPeakCurrent(self,varargin)
     %Usage: retval = setPeakCurrent (m, val)
     %
     %m is of type int. val is of type double const. m is of type int. val is of type double const. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1251, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1237, self, varargin{:});
     end
     function varargout = getPWM(self,varargin)
     %Usage: retval = getPWM (j, val)
     %
     %j is of type int. val is of type double *. j is of type int. val is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1252, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1238, self, varargin{:});
     end
     function varargout = getPWMLimit(self,varargin)
     %Usage: retval = getPWMLimit (j, val)
     %
     %j is of type int. val is of type double *. j is of type int. val is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1253, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1239, self, varargin{:});
     end
     function varargout = setPWMLimit(self,varargin)
     %Usage: retval = setPWMLimit (j, val)
     %
     %j is of type int. val is of type double const. j is of type int. val is of type double const. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1254, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1240, self, varargin{:});
     end
     function varargout = getPowerSupplyVoltage(self,varargin)
     %Usage: retval = getPowerSupplyVoltage (j, val)
     %
     %j is of type int. val is of type double *. j is of type int. val is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1255, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1241, self, varargin{:});
     end
     function varargout = getCurrents(self,varargin)
     %Usage: retval = getCurrents (data)
     %
     %data is of type DVector. data is of type DVector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1256, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1242, self, varargin{:});
     end
     function varargout = getCurrent(self,varargin)
     %Usage: retval = getCurrent (j, data)
     %
     %j is of type int. data is of type DVector. j is of type int. data is of type DVector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1257, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1243, self, varargin{:});
     end
     function self = IAmplifierControl(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/IAmplifierControlRaw.m
+++ b/matlab/autogenerated/+yarp/IAmplifierControlRaw.m
@@ -7,7 +7,7 @@ classdef IAmplifierControlRaw < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1258, self);
+        yarpMEX(1244, self);
         self.SwigClear();
       end
     end
@@ -15,91 +15,91 @@ classdef IAmplifierControlRaw < SwigRef
     %Usage: retval = enableAmpRaw (j)
     %
     %j is of type int. j is of type int. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1259, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1245, self, varargin{:});
     end
     function varargout = disableAmpRaw(self,varargin)
     %Usage: retval = disableAmpRaw (j)
     %
     %j is of type int. j is of type int. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1260, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1246, self, varargin{:});
     end
     function varargout = getAmpStatusRaw(self,varargin)
     %Usage: retval = getAmpStatusRaw (j, st)
     %
     %j is of type int. st is of type int *. j is of type int. st is of type int *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1261, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1247, self, varargin{:});
     end
     function varargout = getCurrentsRaw(self,varargin)
     %Usage: retval = getCurrentsRaw (vals)
     %
     %vals is of type double *. vals is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1262, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1248, self, varargin{:});
     end
     function varargout = getCurrentRaw(self,varargin)
     %Usage: retval = getCurrentRaw (j, val)
     %
     %j is of type int. val is of type double *. j is of type int. val is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1263, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1249, self, varargin{:});
     end
     function varargout = setMaxCurrentRaw(self,varargin)
     %Usage: retval = setMaxCurrentRaw (j, v)
     %
     %j is of type int. v is of type double. j is of type int. v is of type double. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1264, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1250, self, varargin{:});
     end
     function varargout = getMaxCurrentRaw(self,varargin)
     %Usage: retval = getMaxCurrentRaw (j, v)
     %
     %j is of type int. v is of type double *. j is of type int. v is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1265, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1251, self, varargin{:});
     end
     function varargout = getNominalCurrentRaw(self,varargin)
     %Usage: retval = getNominalCurrentRaw (m, val)
     %
     %m is of type int. val is of type double *. m is of type int. val is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1266, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1252, self, varargin{:});
     end
     function varargout = setNominalCurrentRaw(self,varargin)
     %Usage: retval = setNominalCurrentRaw (m, val)
     %
     %m is of type int. val is of type double const. m is of type int. val is of type double const. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1267, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1253, self, varargin{:});
     end
     function varargout = getPeakCurrentRaw(self,varargin)
     %Usage: retval = getPeakCurrentRaw (m, val)
     %
     %m is of type int. val is of type double *. m is of type int. val is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1268, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1254, self, varargin{:});
     end
     function varargout = setPeakCurrentRaw(self,varargin)
     %Usage: retval = setPeakCurrentRaw (m, val)
     %
     %m is of type int. val is of type double const. m is of type int. val is of type double const. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1269, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1255, self, varargin{:});
     end
     function varargout = getPWMRaw(self,varargin)
     %Usage: retval = getPWMRaw (j, val)
     %
     %j is of type int. val is of type double *. j is of type int. val is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1270, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1256, self, varargin{:});
     end
     function varargout = getPWMLimitRaw(self,varargin)
     %Usage: retval = getPWMLimitRaw (j, val)
     %
     %j is of type int. val is of type double *. j is of type int. val is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1271, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1257, self, varargin{:});
     end
     function varargout = setPWMLimitRaw(self,varargin)
     %Usage: retval = setPWMLimitRaw (j, val)
     %
     %j is of type int. val is of type double const. j is of type int. val is of type double const. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1272, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1258, self, varargin{:});
     end
     function varargout = getPowerSupplyVoltageRaw(self,varargin)
     %Usage: retval = getPowerSupplyVoltageRaw (j, val)
     %
     %j is of type int. val is of type double *. j is of type int. val is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1273, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1259, self, varargin{:});
     end
     function self = IAmplifierControlRaw(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/IAnalogSensor.m
+++ b/matlab/autogenerated/+yarp/IAnalogSensor.m
@@ -7,7 +7,7 @@ classdef IAnalogSensor < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1717, self);
+        yarpMEX(1703, self);
         self.SwigClear();
       end
     end
@@ -15,31 +15,31 @@ classdef IAnalogSensor < SwigRef
     %Usage: retval = read (out)
     %
     %out is of type Vector. out is of type Vector. retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(1718, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1704, self, varargin{:});
     end
     function varargout = getState(self,varargin)
     %Usage: retval = getState (ch)
     %
     %ch is of type int. ch is of type int. retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(1719, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1705, self, varargin{:});
     end
     function varargout = getChannels(self,varargin)
     %Usage: retval = getChannels ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(1720, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1706, self, varargin{:});
     end
     function varargout = calibrateSensor(self,varargin)
     %Usage: retval = calibrateSensor (value)
     %
     %value is of type Vector. value is of type Vector. retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(1721, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1707, self, varargin{:});
     end
     function varargout = calibrateChannel(self,varargin)
     %Usage: retval = calibrateChannel (ch, value)
     %
     %ch is of type int. value is of type double. ch is of type int. value is of type double. retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(1722, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1708, self, varargin{:});
     end
     function self = IAnalogSensor(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/IAudioVisualGrabber.m
+++ b/matlab/autogenerated/+yarp/IAudioVisualGrabber.m
@@ -7,7 +7,7 @@ classdef IAudioVisualGrabber < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1218, self);
+        yarpMEX(1204, self);
         self.SwigClear();
       end
     end
@@ -15,7 +15,7 @@ classdef IAudioVisualGrabber < SwigRef
     %Usage: retval = getAudioVisual (image, sound)
     %
     %image is of type ImageRgb. sound is of type Sound. image is of type ImageRgb. sound is of type Sound. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1219, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1205, self, varargin{:});
     end
     function self = IAudioVisualGrabber(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/IAudioVisualStream.m
+++ b/matlab/autogenerated/+yarp/IAudioVisualStream.m
@@ -7,7 +7,7 @@ classdef IAudioVisualStream < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1222, self);
+        yarpMEX(1208, self);
         self.SwigClear();
       end
     end
@@ -15,19 +15,19 @@ classdef IAudioVisualStream < SwigRef
     %Usage: retval = hasAudio ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1223, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1209, self, varargin{:});
     end
     function varargout = hasVideo(self,varargin)
     %Usage: retval = hasVideo ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1224, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1210, self, varargin{:});
     end
     function varargout = hasRawVideo(self,varargin)
     %Usage: retval = hasRawVideo ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1225, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1211, self, varargin{:});
     end
     function self = IAudioVisualStream(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/IAxisInfo.m
+++ b/matlab/autogenerated/+yarp/IAxisInfo.m
@@ -7,7 +7,7 @@ classdef IAxisInfo < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1302, self);
+        yarpMEX(1288, self);
         self.SwigClear();
       end
     end
@@ -15,13 +15,13 @@ classdef IAxisInfo < SwigRef
     %Usage: retval = getJointType (axis, type)
     %
     %axis is of type int. type is of type yarp::dev::JointTypeEnum &. axis is of type int. type is of type yarp::dev::JointTypeEnum &. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1303, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1289, self, varargin{:});
     end
     function varargout = getAxisName(self,varargin)
     %Usage: retval = getAxisName (axis)
     %
     %axis is of type int. axis is of type int. retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(1304, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1290, self, varargin{:});
     end
     function self = IAxisInfo(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/IAxisInfoRaw.m
+++ b/matlab/autogenerated/+yarp/IAxisInfoRaw.m
@@ -7,7 +7,7 @@ classdef IAxisInfoRaw < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1305, self);
+        yarpMEX(1291, self);
         self.SwigClear();
       end
     end
@@ -15,13 +15,13 @@ classdef IAxisInfoRaw < SwigRef
     %Usage: retval = getAxisNameRaw (axis, name)
     %
     %axis is of type int. name is of type std::string &. axis is of type int. name is of type std::string &. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1306, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1292, self, varargin{:});
     end
     function varargout = getJointTypeRaw(self,varargin)
     %Usage: retval = getJointTypeRaw (axis, type)
     %
     %axis is of type int. type is of type yarp::dev::JointTypeEnum &. axis is of type int. type is of type yarp::dev::JointTypeEnum &. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1307, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1293, self, varargin{:});
     end
     function self = IAxisInfoRaw(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/ICalibrator.m
+++ b/matlab/autogenerated/+yarp/ICalibrator.m
@@ -7,7 +7,7 @@ classdef ICalibrator < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1553, self);
+        yarpMEX(1539, self);
         self.SwigClear();
       end
     end
@@ -15,25 +15,25 @@ classdef ICalibrator < SwigRef
     %Usage: retval = calibrate (dd)
     %
     %dd is of type DeviceDriver. dd is of type DeviceDriver. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1554, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1540, self, varargin{:});
     end
     function varargout = park(self,varargin)
     %Usage: retval = park (dd)
     %
     %dd is of type DeviceDriver. dd is of type DeviceDriver. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1555, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1541, self, varargin{:});
     end
     function varargout = quitCalibrate(self,varargin)
     %Usage: retval = quitCalibrate ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1556, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1542, self, varargin{:});
     end
     function varargout = quitPark(self,varargin)
     %Usage: retval = quitPark ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1557, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1543, self, varargin{:});
     end
     function self = ICalibrator(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/ICartesianControl.m
+++ b/matlab/autogenerated/+yarp/ICartesianControl.m
@@ -7,7 +7,7 @@ classdef ICartesianControl < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1355, self);
+        yarpMEX(1341, self);
         self.SwigClear();
       end
     end
@@ -15,265 +15,265 @@ classdef ICartesianControl < SwigRef
     %Usage: retval = setTrackingMode (f)
     %
     %f is of type bool const. f is of type bool const. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1356, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1342, self, varargin{:});
     end
     function varargout = getTrackingMode(self,varargin)
     %Usage: retval = getTrackingMode (f)
     %
     %f is of type bool *. f is of type bool *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1357, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1343, self, varargin{:});
     end
     function varargout = setReferenceMode(self,varargin)
     %Usage: retval = setReferenceMode (f)
     %
     %f is of type bool const. f is of type bool const. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1358, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1344, self, varargin{:});
     end
     function varargout = getReferenceMode(self,varargin)
     %Usage: retval = getReferenceMode (f)
     %
     %f is of type bool *. f is of type bool *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1359, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1345, self, varargin{:});
     end
     function varargout = setPosePriority(self,varargin)
     %Usage: retval = setPosePriority (p)
     %
     %p is of type std::string const &. p is of type std::string const &. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1360, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1346, self, varargin{:});
     end
     function varargout = getPosePriority(self,varargin)
     %Usage: retval = getPosePriority (p)
     %
     %p is of type std::string &. p is of type std::string &. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1361, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1347, self, varargin{:});
     end
     function varargout = getPose(self,varargin)
     %Usage: retval = getPose (axis, x, o)
     %
     %axis is of type int const. x is of type Vector. o is of type Vector. axis is of type int const. x is of type Vector. o is of type Vector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1362, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1348, self, varargin{:});
     end
     function varargout = goToPose(self,varargin)
     %Usage: retval = goToPose (xd, od)
     %
     %xd is of type Vector. od is of type Vector. xd is of type Vector. od is of type Vector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1363, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1349, self, varargin{:});
     end
     function varargout = goToPosition(self,varargin)
     %Usage: retval = goToPosition (xd)
     %
     %xd is of type Vector. xd is of type Vector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1364, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1350, self, varargin{:});
     end
     function varargout = goToPoseSync(self,varargin)
     %Usage: retval = goToPoseSync (xd, od)
     %
     %xd is of type Vector. od is of type Vector. xd is of type Vector. od is of type Vector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1365, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1351, self, varargin{:});
     end
     function varargout = goToPositionSync(self,varargin)
     %Usage: retval = goToPositionSync (xd)
     %
     %xd is of type Vector. xd is of type Vector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1366, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1352, self, varargin{:});
     end
     function varargout = getDesired(self,varargin)
     %Usage: retval = getDesired (xdhat, odhat, qdhat)
     %
     %xdhat is of type Vector. odhat is of type Vector. qdhat is of type Vector. xdhat is of type Vector. odhat is of type Vector. qdhat is of type Vector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1367, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1353, self, varargin{:});
     end
     function varargout = askForPose(self,varargin)
     %Usage: retval = askForPose (q0, xd, od, xdhat, odhat, qdhat)
     %
     %q0 is of type Vector. xd is of type Vector. od is of type Vector. xdhat is of type Vector. odhat is of type Vector. qdhat is of type Vector. q0 is of type Vector. xd is of type Vector. od is of type Vector. xdhat is of type Vector. odhat is of type Vector. qdhat is of type Vector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1368, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1354, self, varargin{:});
     end
     function varargout = askForPosition(self,varargin)
     %Usage: retval = askForPosition (q0, xd, xdhat, odhat, qdhat)
     %
     %q0 is of type Vector. xd is of type Vector. xdhat is of type Vector. odhat is of type Vector. qdhat is of type Vector. q0 is of type Vector. xd is of type Vector. xdhat is of type Vector. odhat is of type Vector. qdhat is of type Vector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1369, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1355, self, varargin{:});
     end
     function varargout = getDOF(self,varargin)
     %Usage: retval = getDOF (curDof)
     %
     %curDof is of type Vector. curDof is of type Vector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1370, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1356, self, varargin{:});
     end
     function varargout = setDOF(self,varargin)
     %Usage: retval = setDOF (newDof, curDof)
     %
     %newDof is of type Vector. curDof is of type Vector. newDof is of type Vector. curDof is of type Vector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1371, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1357, self, varargin{:});
     end
     function varargout = getRestPos(self,varargin)
     %Usage: retval = getRestPos (curRestPos)
     %
     %curRestPos is of type Vector. curRestPos is of type Vector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1372, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1358, self, varargin{:});
     end
     function varargout = setRestPos(self,varargin)
     %Usage: retval = setRestPos (newRestPos, curRestPos)
     %
     %newRestPos is of type Vector. curRestPos is of type Vector. newRestPos is of type Vector. curRestPos is of type Vector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1373, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1359, self, varargin{:});
     end
     function varargout = getRestWeights(self,varargin)
     %Usage: retval = getRestWeights (curRestWeights)
     %
     %curRestWeights is of type Vector. curRestWeights is of type Vector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1374, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1360, self, varargin{:});
     end
     function varargout = setRestWeights(self,varargin)
     %Usage: retval = setRestWeights (newRestWeights, curRestWeights)
     %
     %newRestWeights is of type Vector. curRestWeights is of type Vector. newRestWeights is of type Vector. curRestWeights is of type Vector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1375, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1361, self, varargin{:});
     end
     function varargout = getLimits(self,varargin)
     %Usage: retval = getLimits (axis, min, max)
     %
     %axis is of type int const. min is of type double *. max is of type double *. axis is of type int const. min is of type double *. max is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1376, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1362, self, varargin{:});
     end
     function varargout = setLimits(self,varargin)
     %Usage: retval = setLimits (axis, min, max)
     %
     %axis is of type int const. min is of type double const. max is of type double const. axis is of type int const. min is of type double const. max is of type double const. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1377, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1363, self, varargin{:});
     end
     function varargout = getTrajTime(self,varargin)
     %Usage: retval = getTrajTime (t)
     %
     %t is of type double *. t is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1378, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1364, self, varargin{:});
     end
     function varargout = setTrajTime(self,varargin)
     %Usage: retval = setTrajTime (t)
     %
     %t is of type double const. t is of type double const. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1379, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1365, self, varargin{:});
     end
     function varargout = getInTargetTol(self,varargin)
     %Usage: retval = getInTargetTol (tol)
     %
     %tol is of type double *. tol is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1380, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1366, self, varargin{:});
     end
     function varargout = setInTargetTol(self,varargin)
     %Usage: retval = setInTargetTol (tol)
     %
     %tol is of type double const. tol is of type double const. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1381, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1367, self, varargin{:});
     end
     function varargout = getJointsVelocities(self,varargin)
     %Usage: retval = getJointsVelocities (qdot)
     %
     %qdot is of type Vector. qdot is of type Vector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1382, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1368, self, varargin{:});
     end
     function varargout = getTaskVelocities(self,varargin)
     %Usage: retval = getTaskVelocities (xdot, odot)
     %
     %xdot is of type Vector. odot is of type Vector. xdot is of type Vector. odot is of type Vector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1383, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1369, self, varargin{:});
     end
     function varargout = setTaskVelocities(self,varargin)
     %Usage: retval = setTaskVelocities (xdot, odot)
     %
     %xdot is of type Vector. odot is of type Vector. xdot is of type Vector. odot is of type Vector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1384, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1370, self, varargin{:});
     end
     function varargout = attachTipFrame(self,varargin)
     %Usage: retval = attachTipFrame (x, o)
     %
     %x is of type Vector. o is of type Vector. x is of type Vector. o is of type Vector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1385, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1371, self, varargin{:});
     end
     function varargout = getTipFrame(self,varargin)
     %Usage: retval = getTipFrame (x, o)
     %
     %x is of type Vector. o is of type Vector. x is of type Vector. o is of type Vector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1386, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1372, self, varargin{:});
     end
     function varargout = removeTipFrame(self,varargin)
     %Usage: retval = removeTipFrame ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1387, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1373, self, varargin{:});
     end
     function varargout = waitMotionDone(self,varargin)
     %Usage: retval = waitMotionDone ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1388, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1374, self, varargin{:});
     end
     function varargout = stopControl(self,varargin)
     %Usage: retval = stopControl ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1389, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1375, self, varargin{:});
     end
     function varargout = restoreContext(self,varargin)
     %Usage: retval = restoreContext (id)
     %
     %id is of type int const. id is of type int const. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1390, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1376, self, varargin{:});
     end
     function varargout = deleteContext(self,varargin)
     %Usage: retval = deleteContext (id)
     %
     %id is of type int const. id is of type int const. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1391, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1377, self, varargin{:});
     end
     function varargout = getInfo(self,varargin)
     %Usage: retval = getInfo (info)
     %
     %info is of type Bottle. info is of type Bottle. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1392, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1378, self, varargin{:});
     end
     function varargout = registerEvent(self,varargin)
     %Usage: retval = registerEvent (event)
     %
     %event is of type CartesianEvent. event is of type CartesianEvent. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1393, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1379, self, varargin{:});
     end
     function varargout = unregisterEvent(self,varargin)
     %Usage: retval = unregisterEvent (event)
     %
     %event is of type CartesianEvent. event is of type CartesianEvent. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1394, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1380, self, varargin{:});
     end
     function varargout = tweakSet(self,varargin)
     %Usage: retval = tweakSet (options)
     %
     %options is of type Bottle. options is of type Bottle. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1395, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1381, self, varargin{:});
     end
     function varargout = tweakGet(self,varargin)
     %Usage: retval = tweakGet (options)
     %
     %options is of type Bottle. options is of type Bottle. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1396, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1382, self, varargin{:});
     end
     function varargout = checkMotionDone(self,varargin)
     %Usage: retval = checkMotionDone ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1397, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1383, self, varargin{:});
     end
     function varargout = isMotionDone(self,varargin)
     %Usage: retval = isMotionDone ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1398, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1384, self, varargin{:});
     end
     function varargout = storeContext(self,varargin)
     %Usage: retval = storeContext ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(1399, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1385, self, varargin{:});
     end
     function self = ICartesianControl(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/IConfig.m
+++ b/matlab/autogenerated/+yarp/IConfig.m
@@ -7,7 +7,7 @@ classdef IConfig < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1049, self);
+        yarpMEX(1035, self);
         self.SwigClear();
       end
     end
@@ -15,19 +15,19 @@ classdef IConfig < SwigRef
     %Usage: retval = open (config)
     %
     %config is of type Searchable. config is of type Searchable. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1050, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1036, self, varargin{:});
     end
     function varargout = close(self,varargin)
     %Usage: retval = close ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1051, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1037, self, varargin{:});
     end
     function varargout = configure(self,varargin)
     %Usage: retval = configure (config)
     %
     %config is of type Searchable. config is of type Searchable. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1052, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1038, self, varargin{:});
     end
     function self = IConfig(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -35,7 +35,7 @@ classdef IConfig < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(1053, varargin{:});
+        tmp = yarpMEX(1039, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end

--- a/matlab/autogenerated/+yarp/IControlCalibration.m
+++ b/matlab/autogenerated/+yarp/IControlCalibration.m
@@ -7,7 +7,7 @@ classdef IControlCalibration < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1279, self);
+        yarpMEX(1265, self);
         self.SwigClear();
       end
     end
@@ -15,49 +15,49 @@ classdef IControlCalibration < SwigRef
     %Usage: retval = calibrate2 (axis, type, p1, p2, p3)
     %
     %axis is of type int. type is of type unsigned int. p1 is of type double. p2 is of type double. p3 is of type double. axis is of type int. type is of type unsigned int. p1 is of type double. p2 is of type double. p3 is of type double. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1280, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1266, self, varargin{:});
     end
     function varargout = setCalibrationParameters(self,varargin)
     %Usage: retval = setCalibrationParameters (axis, params)
     %
     %axis is of type int. params is of type CalibrationParameters. axis is of type int. params is of type CalibrationParameters. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1281, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1267, self, varargin{:});
     end
     function varargout = done(self,varargin)
     %Usage: retval = done (j)
     %
     %j is of type int. j is of type int. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1282, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1268, self, varargin{:});
     end
     function varargout = setCalibrator(self,varargin)
     %Usage: retval = setCalibrator (c)
     %
     %c is of type ICalibrator *. c is of type ICalibrator *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1283, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1269, self, varargin{:});
     end
     function varargout = calibrate(self,varargin)
     %Usage: retval = calibrate ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1284, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1270, self, varargin{:});
     end
     function varargout = park(self,varargin)
     %Usage: retval = park ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1285, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1271, self, varargin{:});
     end
     function varargout = abortCalibration(self,varargin)
     %Usage: retval = abortCalibration ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1286, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1272, self, varargin{:});
     end
     function varargout = abortPark(self,varargin)
     %Usage: retval = abortPark ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1287, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1273, self, varargin{:});
     end
     function self = IControlCalibration(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/IControlCalibrationRaw.m
+++ b/matlab/autogenerated/+yarp/IControlCalibrationRaw.m
@@ -7,7 +7,7 @@ classdef IControlCalibrationRaw < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1274, self);
+        yarpMEX(1260, self);
         self.SwigClear();
       end
     end
@@ -15,25 +15,25 @@ classdef IControlCalibrationRaw < SwigRef
     %Usage: retval = calibrate2Raw (axis, type, p1, p2, p3)
     %
     %axis is of type int. type is of type unsigned int. p1 is of type double. p2 is of type double. p3 is of type double. axis is of type int. type is of type unsigned int. p1 is of type double. p2 is of type double. p3 is of type double. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1275, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1261, self, varargin{:});
     end
     function varargout = doneRaw(self,varargin)
     %Usage: retval = doneRaw (j)
     %
     %j is of type int. j is of type int. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1276, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1262, self, varargin{:});
     end
     function varargout = calibrateRaw(self,varargin)
     %Usage: retval = calibrateRaw (axis, type, p1, p2, p3)
     %
     %axis is of type int. type is of type unsigned int. p1 is of type double. p2 is of type double. p3 is of type double. axis is of type int. type is of type unsigned int. p1 is of type double. p2 is of type double. p3 is of type double. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1277, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1263, self, varargin{:});
     end
     function varargout = setCalibrationParametersRaw(self,varargin)
     %Usage: retval = setCalibrationParametersRaw (axis, params)
     %
     %axis is of type int. params is of type CalibrationParameters. axis is of type int. params is of type CalibrationParameters. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1278, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1264, self, varargin{:});
     end
     function self = IControlCalibrationRaw(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/IControlDebug.m
+++ b/matlab/autogenerated/+yarp/IControlDebug.m
@@ -7,7 +7,7 @@ classdef IControlDebug < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1288, self);
+        yarpMEX(1274, self);
         self.SwigClear();
       end
     end
@@ -15,19 +15,19 @@ classdef IControlDebug < SwigRef
     %Usage: retval = setPrintFunction (f)
     %
     %f is of type int (*)(char const *,...). f is of type int (*)(char const *,...). retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1289, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1275, self, varargin{:});
     end
     function varargout = loadBootMemory(self,varargin)
     %Usage: retval = loadBootMemory ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1290, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1276, self, varargin{:});
     end
     function varargout = saveBootMemory(self,varargin)
     %Usage: retval = saveBootMemory ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1291, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1277, self, varargin{:});
     end
     function self = IControlDebug(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/IControlLimits.m
+++ b/matlab/autogenerated/+yarp/IControlLimits.m
@@ -7,7 +7,7 @@ classdef IControlLimits < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1292, self);
+        yarpMEX(1278, self);
         self.SwigClear();
       end
     end
@@ -15,25 +15,25 @@ classdef IControlLimits < SwigRef
     %Usage: retval = setLimits (axis, min, max)
     %
     %axis is of type int. min is of type double. max is of type double. axis is of type int. min is of type double. max is of type double. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1293, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1279, self, varargin{:});
     end
     function varargout = setVelLimits(self,varargin)
     %Usage: retval = setVelLimits (axis, min, max)
     %
     %axis is of type int. min is of type double. max is of type double. axis is of type int. min is of type double. max is of type double. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1294, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1280, self, varargin{:});
     end
     function varargout = getVelLimits(self,varargin)
     %Usage: retval = getVelLimits (axis, min, max)
     %
     %axis is of type int. min is of type double *. max is of type double *. axis is of type int. min is of type double *. max is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1295, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1281, self, varargin{:});
     end
     function varargout = getLimits(self,varargin)
     %Usage: retval = getLimits (axis, min, max)
     %
     %axis is of type int. min is of type DVector. max is of type DVector. axis is of type int. min is of type DVector. max is of type DVector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1296, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1282, self, varargin{:});
     end
     function self = IControlLimits(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/IControlLimitsRaw.m
+++ b/matlab/autogenerated/+yarp/IControlLimitsRaw.m
@@ -7,7 +7,7 @@ classdef IControlLimitsRaw < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1297, self);
+        yarpMEX(1283, self);
         self.SwigClear();
       end
     end
@@ -15,25 +15,25 @@ classdef IControlLimitsRaw < SwigRef
     %Usage: retval = setLimitsRaw (axis, min, max)
     %
     %axis is of type int. min is of type double. max is of type double. axis is of type int. min is of type double. max is of type double. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1298, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1284, self, varargin{:});
     end
     function varargout = getLimitsRaw(self,varargin)
     %Usage: retval = getLimitsRaw (axis, min, max)
     %
     %axis is of type int. min is of type double *. max is of type double *. axis is of type int. min is of type double *. max is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1299, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1285, self, varargin{:});
     end
     function varargout = setVelLimitsRaw(self,varargin)
     %Usage: retval = setVelLimitsRaw (axis, min, max)
     %
     %axis is of type int. min is of type double. max is of type double. axis is of type int. min is of type double. max is of type double. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1300, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1286, self, varargin{:});
     end
     function varargout = getVelLimitsRaw(self,varargin)
     %Usage: retval = getVelLimitsRaw (axis, min, max)
     %
     %axis is of type int. min is of type double *. max is of type double *. axis is of type int. min is of type double *. max is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1301, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1287, self, varargin{:});
     end
     function self = IControlLimitsRaw(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/IControlMode.m
+++ b/matlab/autogenerated/+yarp/IControlMode.m
@@ -7,7 +7,7 @@ classdef IControlMode < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1571, self);
+        yarpMEX(1557, self);
         self.SwigClear();
       end
     end
@@ -15,25 +15,25 @@ classdef IControlMode < SwigRef
     %Usage: retval = setControlMode (j, mode)
     %
     %j is of type int const. mode is of type int const. j is of type int const. mode is of type int const. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1572, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1558, self, varargin{:});
     end
     function varargout = getControlMode(self,varargin)
     %Usage: retval = getControlMode (j)
     %
     %j is of type int. j is of type int. retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(1573, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1559, self, varargin{:});
     end
     function varargout = getControlModes(self,varargin)
     %Usage: retval = getControlModes (n_joint, joints, data)
     %
     %n_joint is of type int. joints is of type IVector. data is of type IVector. n_joint is of type int. joints is of type IVector. data is of type IVector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1574, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1560, self, varargin{:});
     end
     function varargout = setControlModes(self,varargin)
     %Usage: retval = setControlModes (n_joint, joints, data)
     %
     %n_joint is of type int. joints is of type IVector. data is of type IVector. n_joint is of type int. joints is of type IVector. data is of type IVector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1575, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1561, self, varargin{:});
     end
     function self = IControlMode(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/IControlModeRaw.m
+++ b/matlab/autogenerated/+yarp/IControlModeRaw.m
@@ -7,7 +7,7 @@ classdef IControlModeRaw < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1576, self);
+        yarpMEX(1562, self);
         self.SwigClear();
       end
     end
@@ -15,25 +15,25 @@ classdef IControlModeRaw < SwigRef
     %Usage: retval = getControlModeRaw (j, mode)
     %
     %j is of type int. mode is of type int *. j is of type int. mode is of type int *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1577, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1563, self, varargin{:});
     end
     function varargout = getControlModesRaw(self,varargin)
     %Usage: retval = getControlModesRaw (n_joint, joints, modes)
     %
     %n_joint is of type int const. joints is of type int const *. modes is of type int *. n_joint is of type int const. joints is of type int const *. modes is of type int *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1578, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1564, self, varargin{:});
     end
     function varargout = setControlModeRaw(self,varargin)
     %Usage: retval = setControlModeRaw (j, mode)
     %
     %j is of type int const. mode is of type int const. j is of type int const. mode is of type int const. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1579, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1565, self, varargin{:});
     end
     function varargout = setControlModesRaw(self,varargin)
     %Usage: retval = setControlModesRaw (modes)
     %
     %modes is of type int *. modes is of type int *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1580, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1566, self, varargin{:});
     end
     function self = IControlModeRaw(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/ICurrentControl.m
+++ b/matlab/autogenerated/+yarp/ICurrentControl.m
@@ -7,7 +7,7 @@ classdef ICurrentControl < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1697, self);
+        yarpMEX(1683, self);
         self.SwigClear();
       end
     end
@@ -15,55 +15,55 @@ classdef ICurrentControl < SwigRef
     %Usage: retval = getNumberOfMotors (ax)
     %
     %ax is of type int *. ax is of type int *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1698, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1684, self, varargin{:});
     end
     function varargout = getCurrent(self,varargin)
     %Usage: retval = getCurrent (m, curr)
     %
     %m is of type int. curr is of type double *. m is of type int. curr is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1699, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1685, self, varargin{:});
     end
     function varargout = getCurrents(self,varargin)
     %Usage: retval = getCurrents (currs)
     %
     %currs is of type double *. currs is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1700, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1686, self, varargin{:});
     end
     function varargout = getCurrentRange(self,varargin)
     %Usage: retval = getCurrentRange (m, min, max)
     %
     %m is of type int. min is of type double *. max is of type double *. m is of type int. min is of type double *. max is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1701, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1687, self, varargin{:});
     end
     function varargout = getCurrentRanges(self,varargin)
     %Usage: retval = getCurrentRanges (min, max)
     %
     %min is of type double *. max is of type double *. min is of type double *. max is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1702, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1688, self, varargin{:});
     end
     function varargout = setRefCurrent(self,varargin)
     %Usage: retval = setRefCurrent (m, curr)
     %
     %m is of type int. curr is of type double. m is of type int. curr is of type double. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1703, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1689, self, varargin{:});
     end
     function varargout = setRefCurrents(self,varargin)
     %Usage: retval = setRefCurrents (n_motor, motors, currs)
     %
     %n_motor is of type int const. motors is of type int const *. currs is of type double const *. n_motor is of type int const. motors is of type int const *. currs is of type double const *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1704, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1690, self, varargin{:});
     end
     function varargout = getRefCurrents(self,varargin)
     %Usage: retval = getRefCurrents (currs)
     %
     %currs is of type double *. currs is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1705, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1691, self, varargin{:});
     end
     function varargout = getRefCurrent(self,varargin)
     %Usage: retval = getRefCurrent (m, curr)
     %
     %m is of type int. curr is of type double *. m is of type int. curr is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1706, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1692, self, varargin{:});
     end
     function self = ICurrentControl(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/ICurrentControlRaw.m
+++ b/matlab/autogenerated/+yarp/ICurrentControlRaw.m
@@ -7,7 +7,7 @@ classdef ICurrentControlRaw < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1707, self);
+        yarpMEX(1693, self);
         self.SwigClear();
       end
     end
@@ -15,55 +15,55 @@ classdef ICurrentControlRaw < SwigRef
     %Usage: retval = getNumberOfMotorsRaw (number)
     %
     %number is of type int *. number is of type int *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1708, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1694, self, varargin{:});
     end
     function varargout = getCurrentRaw(self,varargin)
     %Usage: retval = getCurrentRaw (m, curr)
     %
     %m is of type int. curr is of type double *. m is of type int. curr is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1709, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1695, self, varargin{:});
     end
     function varargout = getCurrentsRaw(self,varargin)
     %Usage: retval = getCurrentsRaw (currs)
     %
     %currs is of type double *. currs is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1710, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1696, self, varargin{:});
     end
     function varargout = getCurrentRangeRaw(self,varargin)
     %Usage: retval = getCurrentRangeRaw (m, min, max)
     %
     %m is of type int. min is of type double *. max is of type double *. m is of type int. min is of type double *. max is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1711, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1697, self, varargin{:});
     end
     function varargout = getCurrentRangesRaw(self,varargin)
     %Usage: retval = getCurrentRangesRaw (min, max)
     %
     %min is of type double *. max is of type double *. min is of type double *. max is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1712, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1698, self, varargin{:});
     end
     function varargout = setRefCurrentRaw(self,varargin)
     %Usage: retval = setRefCurrentRaw (m, curr)
     %
     %m is of type int. curr is of type double. m is of type int. curr is of type double. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1713, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1699, self, varargin{:});
     end
     function varargout = setRefCurrentsRaw(self,varargin)
     %Usage: retval = setRefCurrentsRaw (n_motor, motors, currs)
     %
     %n_motor is of type int const. motors is of type int const *. currs is of type double const *. n_motor is of type int const. motors is of type int const *. currs is of type double const *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1714, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1700, self, varargin{:});
     end
     function varargout = getRefCurrentsRaw(self,varargin)
     %Usage: retval = getRefCurrentsRaw (currs)
     %
     %currs is of type double *. currs is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1715, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1701, self, varargin{:});
     end
     function varargout = getRefCurrentRaw(self,varargin)
     %Usage: retval = getRefCurrentRaw (m, curr)
     %
     %m is of type int. curr is of type double *. m is of type int. curr is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1716, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1702, self, varargin{:});
     end
     function self = ICurrentControlRaw(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/IEncoders.m
+++ b/matlab/autogenerated/+yarp/IEncoders.m
@@ -7,7 +7,7 @@ classdef IEncoders < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1541, self);
+        yarpMEX(1527, self);
         self.SwigClear();
       end
     end
@@ -15,67 +15,67 @@ classdef IEncoders < SwigRef
     %Usage: retval = resetEncoder (j)
     %
     %j is of type int. j is of type int. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1542, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1528, self, varargin{:});
     end
     function varargout = resetEncoders(self,varargin)
     %Usage: retval = resetEncoders ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1543, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1529, self, varargin{:});
     end
     function varargout = setEncoder(self,varargin)
     %Usage: retval = setEncoder (j, val)
     %
     %j is of type int. val is of type double. j is of type int. val is of type double. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1544, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1530, self, varargin{:});
     end
     function varargout = getAxes(self,varargin)
     %Usage: retval = getAxes ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(1545, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1531, self, varargin{:});
     end
     function varargout = setEncoders(self,varargin)
     %Usage: retval = setEncoders (data)
     %
     %data is of type DVector. data is of type DVector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1546, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1532, self, varargin{:});
     end
     function varargout = getEncoder(self,varargin)
     %Usage: retval = getEncoder (j)
     %
     %j is of type int. j is of type int. retval is of type double. 
-      [varargout{1:nargout}] = yarpMEX(1547, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1533, self, varargin{:});
     end
     function varargout = getEncoders(self,varargin)
     %Usage: retval = getEncoders (data)
     %
     %data is of type DVector. data is of type DVector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1548, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1534, self, varargin{:});
     end
     function varargout = getEncoderSpeed(self,varargin)
     %Usage: retval = getEncoderSpeed (j)
     %
     %j is of type int. j is of type int. retval is of type double. 
-      [varargout{1:nargout}] = yarpMEX(1549, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1535, self, varargin{:});
     end
     function varargout = getEncoderSpeeds(self,varargin)
     %Usage: retval = getEncoderSpeeds (data)
     %
     %data is of type DVector. data is of type DVector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1550, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1536, self, varargin{:});
     end
     function varargout = getEncoderAcceleration(self,varargin)
     %Usage: retval = getEncoderAcceleration (j)
     %
     %j is of type int. j is of type int. retval is of type double. 
-      [varargout{1:nargout}] = yarpMEX(1551, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1537, self, varargin{:});
     end
     function varargout = getEncoderAccelerations(self,varargin)
     %Usage: retval = getEncoderAccelerations (data)
     %
     %data is of type DVector. data is of type DVector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1552, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1538, self, varargin{:});
     end
     function self = IEncoders(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/IEncodersRaw.m
+++ b/matlab/autogenerated/+yarp/IEncodersRaw.m
@@ -7,7 +7,7 @@ classdef IEncodersRaw < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1529, self);
+        yarpMEX(1515, self);
         self.SwigClear();
       end
     end
@@ -15,67 +15,67 @@ classdef IEncodersRaw < SwigRef
     %Usage: retval = getAxes (ax)
     %
     %ax is of type int *. ax is of type int *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1530, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1516, self, varargin{:});
     end
     function varargout = resetEncoderRaw(self,varargin)
     %Usage: retval = resetEncoderRaw (j)
     %
     %j is of type int. j is of type int. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1531, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1517, self, varargin{:});
     end
     function varargout = resetEncodersRaw(self,varargin)
     %Usage: retval = resetEncodersRaw ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1532, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1518, self, varargin{:});
     end
     function varargout = setEncoderRaw(self,varargin)
     %Usage: retval = setEncoderRaw (j, val)
     %
     %j is of type int. val is of type double. j is of type int. val is of type double. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1533, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1519, self, varargin{:});
     end
     function varargout = setEncodersRaw(self,varargin)
     %Usage: retval = setEncodersRaw (vals)
     %
     %vals is of type double const *. vals is of type double const *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1534, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1520, self, varargin{:});
     end
     function varargout = getEncoderRaw(self,varargin)
     %Usage: retval = getEncoderRaw (j, v)
     %
     %j is of type int. v is of type double *. j is of type int. v is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1535, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1521, self, varargin{:});
     end
     function varargout = getEncodersRaw(self,varargin)
     %Usage: retval = getEncodersRaw (encs)
     %
     %encs is of type double *. encs is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1536, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1522, self, varargin{:});
     end
     function varargout = getEncoderSpeedRaw(self,varargin)
     %Usage: retval = getEncoderSpeedRaw (j, sp)
     %
     %j is of type int. sp is of type double *. j is of type int. sp is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1537, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1523, self, varargin{:});
     end
     function varargout = getEncoderSpeedsRaw(self,varargin)
     %Usage: retval = getEncoderSpeedsRaw (spds)
     %
     %spds is of type double *. spds is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1538, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1524, self, varargin{:});
     end
     function varargout = getEncoderAccelerationRaw(self,varargin)
     %Usage: retval = getEncoderAccelerationRaw (j, spds)
     %
     %j is of type int. spds is of type double *. j is of type int. spds is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1539, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1525, self, varargin{:});
     end
     function varargout = getEncoderAccelerationsRaw(self,varargin)
     %Usage: retval = getEncoderAccelerationsRaw (accs)
     %
     %accs is of type double *. accs is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1540, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1526, self, varargin{:});
     end
     function self = IEncodersRaw(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/IFrameGrabber.m
+++ b/matlab/autogenerated/+yarp/IFrameGrabber.m
@@ -7,7 +7,7 @@ classdef IFrameGrabber < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1133, self);
+        yarpMEX(1119, self);
         self.SwigClear();
       end
     end
@@ -15,25 +15,25 @@ classdef IFrameGrabber < SwigRef
     %Usage: retval = getRawBuffer (buffer)
     %
     %buffer is of type unsigned char *. buffer is of type unsigned char *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1134, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1120, self, varargin{:});
     end
     function varargout = getRawBufferSize(self,varargin)
     %Usage: retval = getRawBufferSize ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(1135, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1121, self, varargin{:});
     end
     function varargout = height(self,varargin)
     %Usage: retval = height ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(1136, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1122, self, varargin{:});
     end
     function varargout = width(self,varargin)
     %Usage: retval = width ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(1137, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1123, self, varargin{:});
     end
     function self = IFrameGrabber(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/IFrameGrabberControls.m
+++ b/matlab/autogenerated/+yarp/IFrameGrabberControls.m
@@ -7,7 +7,7 @@ classdef IFrameGrabberControls < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1154, self);
+        yarpMEX(1140, self);
         self.SwigClear();
       end
     end
@@ -15,223 +15,223 @@ classdef IFrameGrabberControls < SwigRef
     %Usage: retval = setBrightness (v)
     %
     %v is of type double. v is of type double. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1155, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1141, self, varargin{:});
     end
     function varargout = setExposure(self,varargin)
     %Usage: retval = setExposure (v)
     %
     %v is of type double. v is of type double. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1156, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1142, self, varargin{:});
     end
     function varargout = setSharpness(self,varargin)
     %Usage: retval = setSharpness (v)
     %
     %v is of type double. v is of type double. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1157, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1143, self, varargin{:});
     end
     function varargout = setWhiteBalance(self,varargin)
     %Usage: retval = setWhiteBalance (blue, red)
     %
     %blue is of type double. red is of type double. blue is of type double. red is of type double. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1158, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1144, self, varargin{:});
     end
     function varargout = setHue(self,varargin)
     %Usage: retval = setHue (v)
     %
     %v is of type double. v is of type double. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1159, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1145, self, varargin{:});
     end
     function varargout = setSaturation(self,varargin)
     %Usage: retval = setSaturation (v)
     %
     %v is of type double. v is of type double. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1160, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1146, self, varargin{:});
     end
     function varargout = setGamma(self,varargin)
     %Usage: retval = setGamma (v)
     %
     %v is of type double. v is of type double. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1161, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1147, self, varargin{:});
     end
     function varargout = setShutter(self,varargin)
     %Usage: retval = setShutter (v)
     %
     %v is of type double. v is of type double. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1162, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1148, self, varargin{:});
     end
     function varargout = setGain(self,varargin)
     %Usage: retval = setGain (v)
     %
     %v is of type double. v is of type double. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1163, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1149, self, varargin{:});
     end
     function varargout = setIris(self,varargin)
     %Usage: retval = setIris (v)
     %
     %v is of type double. v is of type double. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1164, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1150, self, varargin{:});
     end
     function varargout = getBrightness(self,varargin)
     %Usage: retval = getBrightness ()
     %
     %retval is of type double. 
-      [varargout{1:nargout}] = yarpMEX(1165, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1151, self, varargin{:});
     end
     function varargout = getExposure(self,varargin)
     %Usage: retval = getExposure ()
     %
     %retval is of type double. 
-      [varargout{1:nargout}] = yarpMEX(1166, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1152, self, varargin{:});
     end
     function varargout = getSharpness(self,varargin)
     %Usage: retval = getSharpness ()
     %
     %retval is of type double. 
-      [varargout{1:nargout}] = yarpMEX(1167, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1153, self, varargin{:});
     end
     function varargout = getWhiteBalance(self,varargin)
     %Usage: retval = getWhiteBalance (blue, red)
     %
     %blue is of type double &. red is of type double &. blue is of type double &. red is of type double &. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1168, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1154, self, varargin{:});
     end
     function varargout = getHue(self,varargin)
     %Usage: retval = getHue ()
     %
     %retval is of type double. 
-      [varargout{1:nargout}] = yarpMEX(1169, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1155, self, varargin{:});
     end
     function varargout = getSaturation(self,varargin)
     %Usage: retval = getSaturation ()
     %
     %retval is of type double. 
-      [varargout{1:nargout}] = yarpMEX(1170, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1156, self, varargin{:});
     end
     function varargout = getGamma(self,varargin)
     %Usage: retval = getGamma ()
     %
     %retval is of type double. 
-      [varargout{1:nargout}] = yarpMEX(1171, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1157, self, varargin{:});
     end
     function varargout = getShutter(self,varargin)
     %Usage: retval = getShutter ()
     %
     %retval is of type double. 
-      [varargout{1:nargout}] = yarpMEX(1172, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1158, self, varargin{:});
     end
     function varargout = getGain(self,varargin)
     %Usage: retval = getGain ()
     %
     %retval is of type double. 
-      [varargout{1:nargout}] = yarpMEX(1173, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1159, self, varargin{:});
     end
     function varargout = getIris(self,varargin)
     %Usage: retval = getIris ()
     %
     %retval is of type double. 
-      [varargout{1:nargout}] = yarpMEX(1174, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1160, self, varargin{:});
     end
     function varargout = featureVocab2Enum(self,varargin)
     %Usage: retval = featureVocab2Enum (vocab)
     %
     %vocab is of type int. vocab is of type int. retval is of type cameraFeature_id_t. 
-      [varargout{1:nargout}] = yarpMEX(1175, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1161, self, varargin{:});
     end
     function varargout = featureEnum2Vocab(self,varargin)
     %Usage: retval = featureEnum2Vocab (_enum)
     %
     %_enum is of type cameraFeature_id_t. _enum is of type cameraFeature_id_t. retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(1176, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1162, self, varargin{:});
     end
     function varargout = busType2String(self,varargin)
     %Usage: retval = busType2String (type)
     %
     %type is of type BusType. type is of type BusType. retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(1177, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1163, self, varargin{:});
     end
     function varargout = toFeatureMode(self,varargin)
     %Usage: retval = toFeatureMode (_auto)
     %
     %_auto is of type bool. _auto is of type bool. retval is of type FeatureMode. 
-      [varargout{1:nargout}] = yarpMEX(1178, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1164, self, varargin{:});
     end
     function varargout = setFeature(self,varargin)
     %Usage: retval = setFeature (feature, value1, value2)
     %
     %feature is of type int. value1 is of type double. value2 is of type double. feature is of type int. value1 is of type double. value2 is of type double. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1179, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1165, self, varargin{:});
     end
     function varargout = setActive(self,varargin)
     %Usage: retval = setActive (feature, onoff)
     %
     %feature is of type int. onoff is of type bool. feature is of type int. onoff is of type bool. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1180, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1166, self, varargin{:});
     end
     function varargout = setMode(self,varargin)
     %Usage: retval = setMode (feature, mode)
     %
     %feature is of type int. mode is of type FeatureMode. feature is of type int. mode is of type FeatureMode. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1181, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1167, self, varargin{:});
     end
     function varargout = setOnePush(self,varargin)
     %Usage: retval = setOnePush (feature)
     %
     %feature is of type int. feature is of type int. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1182, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1168, self, varargin{:});
     end
     function varargout = getCameraDescription(self,varargin)
     %Usage: retval = getCameraDescription ()
     %
     %retval is of type CameraDescriptor. 
-      [varargout{1:nargout}] = yarpMEX(1183, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1169, self, varargin{:});
     end
     function varargout = hasFeature(self,varargin)
     %Usage: retval = hasFeature (feature)
     %
     %feature is of type int. feature is of type int. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1184, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1170, self, varargin{:});
     end
     function varargout = getFeature(self,varargin)
     %Usage: retval = getFeature (feature)
     %
     %feature is of type int. feature is of type int. retval is of type double. 
-      [varargout{1:nargout}] = yarpMEX(1185, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1171, self, varargin{:});
     end
     function varargout = hasOnOff(self,varargin)
     %Usage: retval = hasOnOff (feature)
     %
     %feature is of type int. feature is of type int. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1186, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1172, self, varargin{:});
     end
     function varargout = getActive(self,varargin)
     %Usage: retval = getActive (feature)
     %
     %feature is of type int. feature is of type int. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1187, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1173, self, varargin{:});
     end
     function varargout = hasAuto(self,varargin)
     %Usage: retval = hasAuto (feature)
     %
     %feature is of type int. feature is of type int. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1188, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1174, self, varargin{:});
     end
     function varargout = hasManual(self,varargin)
     %Usage: retval = hasManual (feature)
     %
     %feature is of type int. feature is of type int. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1189, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1175, self, varargin{:});
     end
     function varargout = hasOnePush(self,varargin)
     %Usage: retval = hasOnePush (feature)
     %
     %feature is of type int. feature is of type int. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1190, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1176, self, varargin{:});
     end
     function varargout = getMode(self,varargin)
     %Usage: retval = getMode (feature)
     %
     %feature is of type int. feature is of type int. retval is of type FeatureMode. 
-      [varargout{1:nargout}] = yarpMEX(1191, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1177, self, varargin{:});
     end
     function self = IFrameGrabberControls(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/IFrameGrabberControlsDC1394.m
+++ b/matlab/autogenerated/+yarp/IFrameGrabberControlsDC1394.m
@@ -7,7 +7,7 @@ classdef IFrameGrabberControlsDC1394 < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1192, self);
+        yarpMEX(1178, self);
         self.SwigClear();
       end
     end
@@ -15,151 +15,151 @@ classdef IFrameGrabberControlsDC1394 < SwigRef
     %Usage: retval = getVideoModeMaskDC1394 ()
     %
     %retval is of type unsigned int. 
-      [varargout{1:nargout}] = yarpMEX(1193, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1179, self, varargin{:});
     end
     function varargout = getVideoModeDC1394(self,varargin)
     %Usage: retval = getVideoModeDC1394 ()
     %
     %retval is of type unsigned int. 
-      [varargout{1:nargout}] = yarpMEX(1194, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1180, self, varargin{:});
     end
     function varargout = setVideoModeDC1394(self,varargin)
     %Usage: retval = setVideoModeDC1394 (video_mode)
     %
     %video_mode is of type int. video_mode is of type int. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1195, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1181, self, varargin{:});
     end
     function varargout = getFPSMaskDC1394(self,varargin)
     %Usage: retval = getFPSMaskDC1394 ()
     %
     %retval is of type unsigned int. 
-      [varargout{1:nargout}] = yarpMEX(1196, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1182, self, varargin{:});
     end
     function varargout = getFPSDC1394(self,varargin)
     %Usage: retval = getFPSDC1394 ()
     %
     %retval is of type unsigned int. 
-      [varargout{1:nargout}] = yarpMEX(1197, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1183, self, varargin{:});
     end
     function varargout = setFPSDC1394(self,varargin)
     %Usage: retval = setFPSDC1394 (fps)
     %
     %fps is of type int. fps is of type int. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1198, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1184, self, varargin{:});
     end
     function varargout = getISOSpeedDC1394(self,varargin)
     %Usage: retval = getISOSpeedDC1394 ()
     %
     %retval is of type unsigned int. 
-      [varargout{1:nargout}] = yarpMEX(1199, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1185, self, varargin{:});
     end
     function varargout = setISOSpeedDC1394(self,varargin)
     %Usage: retval = setISOSpeedDC1394 (speed)
     %
     %speed is of type int. speed is of type int. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1200, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1186, self, varargin{:});
     end
     function varargout = getColorCodingMaskDC1394(self,varargin)
     %Usage: retval = getColorCodingMaskDC1394 (video_mode)
     %
     %video_mode is of type unsigned int. video_mode is of type unsigned int. retval is of type unsigned int. 
-      [varargout{1:nargout}] = yarpMEX(1201, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1187, self, varargin{:});
     end
     function varargout = getColorCodingDC1394(self,varargin)
     %Usage: retval = getColorCodingDC1394 ()
     %
     %retval is of type unsigned int. 
-      [varargout{1:nargout}] = yarpMEX(1202, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1188, self, varargin{:});
     end
     function varargout = setColorCodingDC1394(self,varargin)
     %Usage: retval = setColorCodingDC1394 (coding)
     %
     %coding is of type int. coding is of type int. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1203, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1189, self, varargin{:});
     end
     function varargout = getFormat7MaxWindowDC1394(self,varargin)
     %Usage: retval = getFormat7MaxWindowDC1394 (xdim, ydim, xstep, ystep, xoffstep, yoffstep)
     %
     %xdim is of type unsigned int &. ydim is of type unsigned int &. xstep is of type unsigned int &. ystep is of type unsigned int &. xoffstep is of type unsigned int &. yoffstep is of type unsigned int &. xdim is of type unsigned int &. ydim is of type unsigned int &. xstep is of type unsigned int &. ystep is of type unsigned int &. xoffstep is of type unsigned int &. yoffstep is of type unsigned int &. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1204, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1190, self, varargin{:});
     end
     function varargout = getFormat7WindowDC1394(self,varargin)
     %Usage: retval = getFormat7WindowDC1394 (xdim, ydim, x0, y0)
     %
     %xdim is of type unsigned int &. ydim is of type unsigned int &. x0 is of type int &. y0 is of type int &. xdim is of type unsigned int &. ydim is of type unsigned int &. x0 is of type int &. y0 is of type int &. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1205, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1191, self, varargin{:});
     end
     function varargout = setFormat7WindowDC1394(self,varargin)
     %Usage: retval = setFormat7WindowDC1394 (xdim, ydim, x0, y0)
     %
     %xdim is of type unsigned int. ydim is of type unsigned int. x0 is of type int. y0 is of type int. xdim is of type unsigned int. ydim is of type unsigned int. x0 is of type int. y0 is of type int. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1206, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1192, self, varargin{:});
     end
     function varargout = setOperationModeDC1394(self,varargin)
     %Usage: retval = setOperationModeDC1394 (b1394b)
     %
     %b1394b is of type bool. b1394b is of type bool. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1207, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1193, self, varargin{:});
     end
     function varargout = getOperationModeDC1394(self,varargin)
     %Usage: retval = getOperationModeDC1394 ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1208, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1194, self, varargin{:});
     end
     function varargout = setTransmissionDC1394(self,varargin)
     %Usage: retval = setTransmissionDC1394 (bTxON)
     %
     %bTxON is of type bool. bTxON is of type bool. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1209, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1195, self, varargin{:});
     end
     function varargout = getTransmissionDC1394(self,varargin)
     %Usage: retval = getTransmissionDC1394 ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1210, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1196, self, varargin{:});
     end
     function varargout = setBroadcastDC1394(self,varargin)
     %Usage: retval = setBroadcastDC1394 (onoff)
     %
     %onoff is of type bool. onoff is of type bool. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1211, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1197, self, varargin{:});
     end
     function varargout = setDefaultsDC1394(self,varargin)
     %Usage: retval = setDefaultsDC1394 ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1212, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1198, self, varargin{:});
     end
     function varargout = setResetDC1394(self,varargin)
     %Usage: retval = setResetDC1394 ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1213, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1199, self, varargin{:});
     end
     function varargout = setPowerDC1394(self,varargin)
     %Usage: retval = setPowerDC1394 (onoff)
     %
     %onoff is of type bool. onoff is of type bool. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1214, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1200, self, varargin{:});
     end
     function varargout = setCaptureDC1394(self,varargin)
     %Usage: retval = setCaptureDC1394 (bON)
     %
     %bON is of type bool. bON is of type bool. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1215, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1201, self, varargin{:});
     end
     function varargout = getBytesPerPacketDC1394(self,varargin)
     %Usage: retval = getBytesPerPacketDC1394 ()
     %
     %retval is of type unsigned int. 
-      [varargout{1:nargout}] = yarpMEX(1216, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1202, self, varargin{:});
     end
     function varargout = setBytesPerPacketDC1394(self,varargin)
     %Usage: retval = setBytesPerPacketDC1394 (bpp)
     %
     %bpp is of type unsigned int. bpp is of type unsigned int. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1217, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1203, self, varargin{:});
     end
     function self = IFrameGrabberControlsDC1394(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/IFrameGrabberImage.m
+++ b/matlab/autogenerated/+yarp/IFrameGrabberImage.m
@@ -7,7 +7,7 @@ classdef IFrameGrabberImage < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1142, self);
+        yarpMEX(1128, self);
         self.SwigClear();
       end
     end
@@ -15,25 +15,25 @@ classdef IFrameGrabberImage < SwigRef
     %Usage: retval = getImage (image)
     %
     %image is of type ImageRgb. image is of type ImageRgb. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1143, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1129, self, varargin{:});
     end
     function varargout = getImageCrop(self,varargin)
     %Usage: retval = getImageCrop (cropType, vertices, image)
     %
     %cropType is of type cropType_id_t. vertices is of type yarp::sig::VectorOf< std::pair< int,int > >. image is of type ImageRgb. cropType is of type cropType_id_t. vertices is of type yarp::sig::VectorOf< std::pair< int,int > >. image is of type ImageRgb. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1144, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1130, self, varargin{:});
     end
     function varargout = height(self,varargin)
     %Usage: retval = height ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(1145, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1131, self, varargin{:});
     end
     function varargout = width(self,varargin)
     %Usage: retval = width ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(1146, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1132, self, varargin{:});
     end
     function self = IFrameGrabberImage(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/IFrameGrabberImageRaw.m
+++ b/matlab/autogenerated/+yarp/IFrameGrabberImageRaw.m
@@ -7,7 +7,7 @@ classdef IFrameGrabberImageRaw < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1147, self);
+        yarpMEX(1133, self);
         self.SwigClear();
       end
     end
@@ -15,25 +15,25 @@ classdef IFrameGrabberImageRaw < SwigRef
     %Usage: retval = getImage (image)
     %
     %image is of type ImageMono. image is of type ImageMono. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1148, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1134, self, varargin{:});
     end
     function varargout = getImageCrop(self,varargin)
     %Usage: retval = getImageCrop (cropType, vertices, image)
     %
     %cropType is of type cropType_id_t. vertices is of type yarp::sig::VectorOf< std::pair< int,int > >. image is of type ImageMono. cropType is of type cropType_id_t. vertices is of type yarp::sig::VectorOf< std::pair< int,int > >. image is of type ImageMono. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1149, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1135, self, varargin{:});
     end
     function varargout = height(self,varargin)
     %Usage: retval = height ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(1150, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1136, self, varargin{:});
     end
     function varargout = width(self,varargin)
     %Usage: retval = width ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(1151, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1137, self, varargin{:});
     end
     function self = IFrameGrabberImageRaw(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/IFrameGrabberRgb.m
+++ b/matlab/autogenerated/+yarp/IFrameGrabberRgb.m
@@ -7,7 +7,7 @@ classdef IFrameGrabberRgb < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1138, self);
+        yarpMEX(1124, self);
         self.SwigClear();
       end
     end
@@ -15,19 +15,19 @@ classdef IFrameGrabberRgb < SwigRef
     %Usage: retval = getRgbBuffer (buffer)
     %
     %buffer is of type unsigned char *. buffer is of type unsigned char *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1139, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1125, self, varargin{:});
     end
     function varargout = height(self,varargin)
     %Usage: retval = height ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(1140, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1126, self, varargin{:});
     end
     function varargout = width(self,varargin)
     %Usage: retval = width ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(1141, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1127, self, varargin{:});
     end
     function self = IFrameGrabberRgb(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/IFrameWriterAudioVisual.m
+++ b/matlab/autogenerated/+yarp/IFrameWriterAudioVisual.m
@@ -7,7 +7,7 @@ classdef IFrameWriterAudioVisual < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1220, self);
+        yarpMEX(1206, self);
         self.SwigClear();
       end
     end
@@ -15,7 +15,7 @@ classdef IFrameWriterAudioVisual < SwigRef
     %Usage: retval = putAudioVisual (image, sound)
     %
     %image is of type ImageRgb. sound is of type Sound. image is of type ImageRgb. sound is of type Sound. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1221, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1207, self, varargin{:});
     end
     function self = IFrameWriterAudioVisual(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/IFrameWriterImage.m
+++ b/matlab/autogenerated/+yarp/IFrameWriterImage.m
@@ -7,7 +7,7 @@ classdef IFrameWriterImage < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1152, self);
+        yarpMEX(1138, self);
         self.SwigClear();
       end
     end
@@ -15,7 +15,7 @@ classdef IFrameWriterImage < SwigRef
     %Usage: retval = putImage (image)
     %
     %image is of type ImageRgb. image is of type ImageRgb. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1153, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1139, self, varargin{:});
     end
     function self = IFrameWriterImage(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/IGazeControl.m
+++ b/matlab/autogenerated/+yarp/IGazeControl.m
@@ -7,7 +7,7 @@ classdef IGazeControl < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1420, self);
+        yarpMEX(1406, self);
         self.SwigClear();
       end
     end
@@ -15,451 +15,451 @@ classdef IGazeControl < SwigRef
     %Usage: retval = setTrackingMode (f)
     %
     %f is of type bool const. f is of type bool const. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1421, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1407, self, varargin{:});
     end
     function varargout = setStabilizationMode(self,varargin)
     %Usage: retval = setStabilizationMode (f)
     %
     %f is of type bool const. f is of type bool const. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1422, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1408, self, varargin{:});
     end
     function varargout = getStabilizationMode(self,varargin)
     %Usage: retval = getStabilizationMode (f)
     %
     %f is of type bool *. f is of type bool *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1423, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1409, self, varargin{:});
     end
     function varargout = getFixationPoint(self,varargin)
     %Usage: retval = getFixationPoint (fp)
     %
     %fp is of type Vector. fp is of type Vector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1424, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1410, self, varargin{:});
     end
     function varargout = getAngles(self,varargin)
     %Usage: retval = getAngles (ang)
     %
     %ang is of type Vector. ang is of type Vector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1425, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1411, self, varargin{:});
     end
     function varargout = lookAtFixationPoint(self,varargin)
     %Usage: retval = lookAtFixationPoint (fp)
     %
     %fp is of type Vector. fp is of type Vector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1426, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1412, self, varargin{:});
     end
     function varargout = lookAtAbsAngles(self,varargin)
     %Usage: retval = lookAtAbsAngles (ang)
     %
     %ang is of type Vector. ang is of type Vector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1427, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1413, self, varargin{:});
     end
     function varargout = lookAtRelAngles(self,varargin)
     %Usage: retval = lookAtRelAngles (ang)
     %
     %ang is of type Vector. ang is of type Vector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1428, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1414, self, varargin{:});
     end
     function varargout = lookAtMonoPixel(self,varargin)
     %Usage: retval = lookAtMonoPixel (camSel, px)
     %
     %camSel is of type int const. px is of type Vector. camSel is of type int const. px is of type Vector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1429, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1415, self, varargin{:});
     end
     function varargout = lookAtMonoPixelWithVergence(self,varargin)
     %Usage: retval = lookAtMonoPixelWithVergence (camSel, px, ver)
     %
     %camSel is of type int const. px is of type Vector. ver is of type double const. camSel is of type int const. px is of type Vector. ver is of type double const. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1430, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1416, self, varargin{:});
     end
     function varargout = lookAtStereoPixels(self,varargin)
     %Usage: retval = lookAtStereoPixels (pxl, pxr)
     %
     %pxl is of type Vector. pxr is of type Vector. pxl is of type Vector. pxr is of type Vector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1431, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1417, self, varargin{:});
     end
     function varargout = lookAtFixationPointSync(self,varargin)
     %Usage: retval = lookAtFixationPointSync (fp)
     %
     %fp is of type Vector. fp is of type Vector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1432, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1418, self, varargin{:});
     end
     function varargout = lookAtAbsAnglesSync(self,varargin)
     %Usage: retval = lookAtAbsAnglesSync (ang)
     %
     %ang is of type Vector. ang is of type Vector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1433, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1419, self, varargin{:});
     end
     function varargout = lookAtRelAnglesSync(self,varargin)
     %Usage: retval = lookAtRelAnglesSync (ang)
     %
     %ang is of type Vector. ang is of type Vector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1434, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1420, self, varargin{:});
     end
     function varargout = lookAtMonoPixelSync(self,varargin)
     %Usage: retval = lookAtMonoPixelSync (camSel, px)
     %
     %camSel is of type int const. px is of type Vector. camSel is of type int const. px is of type Vector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1435, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1421, self, varargin{:});
     end
     function varargout = lookAtMonoPixelWithVergenceSync(self,varargin)
     %Usage: retval = lookAtMonoPixelWithVergenceSync (camSel, px, ver)
     %
     %camSel is of type int const. px is of type Vector. ver is of type double const. camSel is of type int const. px is of type Vector. ver is of type double const. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1436, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1422, self, varargin{:});
     end
     function varargout = lookAtStereoPixelsSync(self,varargin)
     %Usage: retval = lookAtStereoPixelsSync (pxl, pxr)
     %
     %pxl is of type Vector. pxr is of type Vector. pxl is of type Vector. pxr is of type Vector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1437, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1423, self, varargin{:});
     end
     function varargout = getVORGain(self,varargin)
     %Usage: retval = getVORGain (gain)
     %
     %gain is of type double *. gain is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1438, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1424, self, varargin{:});
     end
     function varargout = getOCRGain(self,varargin)
     %Usage: retval = getOCRGain (gain)
     %
     %gain is of type double *. gain is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1439, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1425, self, varargin{:});
     end
     function varargout = getSaccadesMode(self,varargin)
     %Usage: retval = getSaccadesMode (f)
     %
     %f is of type bool *. f is of type bool *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1440, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1426, self, varargin{:});
     end
     function varargout = getSaccadesInhibitionPeriod(self,varargin)
     %Usage: retval = getSaccadesInhibitionPeriod (period)
     %
     %period is of type double *. period is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1441, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1427, self, varargin{:});
     end
     function varargout = getSaccadesActivationAngle(self,varargin)
     %Usage: retval = getSaccadesActivationAngle (angle)
     %
     %angle is of type double *. angle is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1442, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1428, self, varargin{:});
     end
     function varargout = getLeftEyePose(self,varargin)
     %Usage: retval = getLeftEyePose (x, od)
     %
     %x is of type Vector. od is of type Vector. x is of type Vector. od is of type Vector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1443, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1429, self, varargin{:});
     end
     function varargout = getRightEyePose(self,varargin)
     %Usage: retval = getRightEyePose (x, od)
     %
     %x is of type Vector. od is of type Vector. x is of type Vector. od is of type Vector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1444, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1430, self, varargin{:});
     end
     function varargout = getHeadPose(self,varargin)
     %Usage: retval = getHeadPose (x, od)
     %
     %x is of type Vector. od is of type Vector. x is of type Vector. od is of type Vector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1445, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1431, self, varargin{:});
     end
     function varargout = get2DPixel(self,varargin)
     %Usage: retval = get2DPixel (camSel, x, px)
     %
     %camSel is of type int const. x is of type Vector. px is of type Vector. camSel is of type int const. x is of type Vector. px is of type Vector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1446, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1432, self, varargin{:});
     end
     function varargout = get3DPoint(self,varargin)
     %Usage: retval = get3DPoint (camSel, px, z, x)
     %
     %camSel is of type int const. px is of type Vector. z is of type double const. x is of type Vector. camSel is of type int const. px is of type Vector. z is of type double const. x is of type Vector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1447, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1433, self, varargin{:});
     end
     function varargout = get3DPointOnPlane(self,varargin)
     %Usage: retval = get3DPointOnPlane (camSel, px, plane, x)
     %
     %camSel is of type int const. px is of type Vector. plane is of type Vector. x is of type Vector. camSel is of type int const. px is of type Vector. plane is of type Vector. x is of type Vector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1448, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1434, self, varargin{:});
     end
     function varargout = get3DPointFromAngles(self,varargin)
     %Usage: retval = get3DPointFromAngles (mode, ang, x)
     %
     %mode is of type int const. ang is of type Vector. x is of type Vector. mode is of type int const. ang is of type Vector. x is of type Vector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1449, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1435, self, varargin{:});
     end
     function varargout = getAnglesFrom3DPoint(self,varargin)
     %Usage: retval = getAnglesFrom3DPoint (x, ang)
     %
     %x is of type Vector. ang is of type Vector. x is of type Vector. ang is of type Vector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1450, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1436, self, varargin{:});
     end
     function varargout = triangulate3DPoint(self,varargin)
     %Usage: retval = triangulate3DPoint (pxl, pxr, x)
     %
     %pxl is of type Vector. pxr is of type Vector. x is of type Vector. pxl is of type Vector. pxr is of type Vector. x is of type Vector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1451, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1437, self, varargin{:});
     end
     function varargout = getJointsDesired(self,varargin)
     %Usage: retval = getJointsDesired (qdes)
     %
     %qdes is of type Vector. qdes is of type Vector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1452, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1438, self, varargin{:});
     end
     function varargout = getJointsVelocities(self,varargin)
     %Usage: retval = getJointsVelocities (qdot)
     %
     %qdot is of type Vector. qdot is of type Vector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1453, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1439, self, varargin{:});
     end
     function varargout = getStereoOptions(self,varargin)
     %Usage: retval = getStereoOptions (options)
     %
     %options is of type Bottle. options is of type Bottle. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1454, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1440, self, varargin{:});
     end
     function varargout = setNeckTrajTime(self,varargin)
     %Usage: retval = setNeckTrajTime (t)
     %
     %t is of type double const. t is of type double const. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1455, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1441, self, varargin{:});
     end
     function varargout = setEyesTrajTime(self,varargin)
     %Usage: retval = setEyesTrajTime (t)
     %
     %t is of type double const. t is of type double const. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1456, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1442, self, varargin{:});
     end
     function varargout = setVORGain(self,varargin)
     %Usage: retval = setVORGain (gain)
     %
     %gain is of type double const. gain is of type double const. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1457, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1443, self, varargin{:});
     end
     function varargout = setOCRGain(self,varargin)
     %Usage: retval = setOCRGain (gain)
     %
     %gain is of type double const. gain is of type double const. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1458, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1444, self, varargin{:});
     end
     function varargout = setSaccadesMode(self,varargin)
     %Usage: retval = setSaccadesMode (f)
     %
     %f is of type bool const. f is of type bool const. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1459, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1445, self, varargin{:});
     end
     function varargout = setSaccadesInhibitionPeriod(self,varargin)
     %Usage: retval = setSaccadesInhibitionPeriod (period)
     %
     %period is of type double const. period is of type double const. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1460, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1446, self, varargin{:});
     end
     function varargout = setSaccadesActivationAngle(self,varargin)
     %Usage: retval = setSaccadesActivationAngle (angle)
     %
     %angle is of type double const. angle is of type double const. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1461, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1447, self, varargin{:});
     end
     function varargout = setStereoOptions(self,varargin)
     %Usage: retval = setStereoOptions (options)
     %
     %options is of type Bottle. options is of type Bottle. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1462, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1448, self, varargin{:});
     end
     function varargout = bindNeckPitch(self,varargin)
     %Usage: retval = bindNeckPitch (min, max)
     %
     %min is of type double const. max is of type double const. min is of type double const. max is of type double const. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1463, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1449, self, varargin{:});
     end
     function varargout = blockNeckPitch(self,varargin)
     %Usage: retval = blockNeckPitch ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1464, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1450, self, varargin{:});
     end
     function varargout = bindNeckRoll(self,varargin)
     %Usage: retval = bindNeckRoll (min, max)
     %
     %min is of type double const. max is of type double const. min is of type double const. max is of type double const. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1465, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1451, self, varargin{:});
     end
     function varargout = blockNeckRoll(self,varargin)
     %Usage: retval = blockNeckRoll ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1466, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1452, self, varargin{:});
     end
     function varargout = bindNeckYaw(self,varargin)
     %Usage: retval = bindNeckYaw (min, max)
     %
     %min is of type double const. max is of type double const. min is of type double const. max is of type double const. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1467, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1453, self, varargin{:});
     end
     function varargout = blockNeckYaw(self,varargin)
     %Usage: retval = blockNeckYaw ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1468, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1454, self, varargin{:});
     end
     function varargout = blockEyes(self,varargin)
     %Usage: retval = blockEyes ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1469, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1455, self, varargin{:});
     end
     function varargout = getNeckPitchRange(self,varargin)
     %Usage: retval = getNeckPitchRange (min, max)
     %
     %min is of type double *. max is of type double *. min is of type double *. max is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1470, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1456, self, varargin{:});
     end
     function varargout = getNeckRollRange(self,varargin)
     %Usage: retval = getNeckRollRange (min, max)
     %
     %min is of type double *. max is of type double *. min is of type double *. max is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1471, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1457, self, varargin{:});
     end
     function varargout = getNeckYawRange(self,varargin)
     %Usage: retval = getNeckYawRange (min, max)
     %
     %min is of type double *. max is of type double *. min is of type double *. max is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1472, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1458, self, varargin{:});
     end
     function varargout = getBlockedVergence(self,varargin)
     %Usage: retval = getBlockedVergence (ver)
     %
     %ver is of type double *. ver is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1473, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1459, self, varargin{:});
     end
     function varargout = clearNeckPitch(self,varargin)
     %Usage: retval = clearNeckPitch ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1474, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1460, self, varargin{:});
     end
     function varargout = clearNeckRoll(self,varargin)
     %Usage: retval = clearNeckRoll ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1475, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1461, self, varargin{:});
     end
     function varargout = clearNeckYaw(self,varargin)
     %Usage: retval = clearNeckYaw ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1476, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1462, self, varargin{:});
     end
     function varargout = clearEyes(self,varargin)
     %Usage: retval = clearEyes ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1477, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1463, self, varargin{:});
     end
     function varargout = getNeckAngleUserTolerance(self,varargin)
     %Usage: retval = getNeckAngleUserTolerance (angle)
     %
     %angle is of type double *. angle is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1478, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1464, self, varargin{:});
     end
     function varargout = setNeckAngleUserTolerance(self,varargin)
     %Usage: retval = setNeckAngleUserTolerance (angle)
     %
     %angle is of type double const. angle is of type double const. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1479, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1465, self, varargin{:});
     end
     function varargout = waitMotionDone(self,varargin)
     %Usage: retval = waitMotionDone ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1480, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1466, self, varargin{:});
     end
     function varargout = checkSaccadeDone(self,varargin)
     %Usage: retval = checkSaccadeDone (f)
     %
     %f is of type bool *. f is of type bool *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1481, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1467, self, varargin{:});
     end
     function varargout = waitSaccadeDone(self,varargin)
     %Usage: retval = waitSaccadeDone ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1482, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1468, self, varargin{:});
     end
     function varargout = stopControl(self,varargin)
     %Usage: retval = stopControl ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1483, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1469, self, varargin{:});
     end
     function varargout = storeContext(self,varargin)
     %Usage: retval = storeContext (id)
     %
     %id is of type int *. id is of type int *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1484, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1470, self, varargin{:});
     end
     function varargout = restoreContext(self,varargin)
     %Usage: retval = restoreContext (id)
     %
     %id is of type int const. id is of type int const. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1485, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1471, self, varargin{:});
     end
     function varargout = deleteContext(self,varargin)
     %Usage: retval = deleteContext (id)
     %
     %id is of type int const. id is of type int const. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1486, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1472, self, varargin{:});
     end
     function varargout = getInfo(self,varargin)
     %Usage: retval = getInfo (info)
     %
     %info is of type Bottle. info is of type Bottle. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1487, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1473, self, varargin{:});
     end
     function varargout = registerEvent(self,varargin)
     %Usage: retval = registerEvent (event)
     %
     %event is of type GazeEvent. event is of type GazeEvent. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1488, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1474, self, varargin{:});
     end
     function varargout = unregisterEvent(self,varargin)
     %Usage: retval = unregisterEvent (event)
     %
     %event is of type GazeEvent. event is of type GazeEvent. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1489, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1475, self, varargin{:});
     end
     function varargout = tweakSet(self,varargin)
     %Usage: retval = tweakSet (options)
     %
     %options is of type Bottle. options is of type Bottle. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1490, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1476, self, varargin{:});
     end
     function varargout = tweakGet(self,varargin)
     %Usage: retval = tweakGet (options)
     %
     %options is of type Bottle. options is of type Bottle. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1491, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1477, self, varargin{:});
     end
     function varargout = getTrackingMode(self,varargin)
     %Usage: retval = getTrackingMode ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1492, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1478, self, varargin{:});
     end
     function varargout = getNeckTrajTime(self,varargin)
     %Usage: retval = getNeckTrajTime ()
     %
     %retval is of type double. 
-      [varargout{1:nargout}] = yarpMEX(1493, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1479, self, varargin{:});
     end
     function varargout = getEyesTrajTime(self,varargin)
     %Usage: retval = getEyesTrajTime ()
     %
     %retval is of type double. 
-      [varargout{1:nargout}] = yarpMEX(1494, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1480, self, varargin{:});
     end
     function varargout = checkMotionDone(self,varargin)
     %Usage: retval = checkMotionDone ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1495, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1481, self, varargin{:});
     end
     function self = IGazeControl(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/IImpedanceControl.m
+++ b/matlab/autogenerated/+yarp/IImpedanceControl.m
@@ -7,7 +7,7 @@ classdef IImpedanceControl < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1654, self);
+        yarpMEX(1640, self);
         self.SwigClear();
       end
     end
@@ -15,37 +15,37 @@ classdef IImpedanceControl < SwigRef
     %Usage: retval = getAxes (ax)
     %
     %ax is of type int *. ax is of type int *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1655, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1641, self, varargin{:});
     end
     function varargout = getImpedance(self,varargin)
     %Usage: retval = getImpedance (j, stiffness, damping)
     %
     %j is of type int. stiffness is of type double *. damping is of type double *. j is of type int. stiffness is of type double *. damping is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1656, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1642, self, varargin{:});
     end
     function varargout = setImpedance(self,varargin)
     %Usage: retval = setImpedance (j, stiffness, damping)
     %
     %j is of type int. stiffness is of type double. damping is of type double. j is of type int. stiffness is of type double. damping is of type double. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1657, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1643, self, varargin{:});
     end
     function varargout = setImpedanceOffset(self,varargin)
     %Usage: retval = setImpedanceOffset (j, offset)
     %
     %j is of type int. offset is of type double. j is of type int. offset is of type double. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1658, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1644, self, varargin{:});
     end
     function varargout = getImpedanceOffset(self,varargin)
     %Usage: retval = getImpedanceOffset (j, offset)
     %
     %j is of type int. offset is of type double *. j is of type int. offset is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1659, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1645, self, varargin{:});
     end
     function varargout = getCurrentImpedanceLimit(self,varargin)
     %Usage: retval = getCurrentImpedanceLimit (j, min_stiff, max_stiff, min_damp, max_damp)
     %
     %j is of type int. min_stiff is of type double *. max_stiff is of type double *. min_damp is of type double *. max_damp is of type double *. j is of type int. min_stiff is of type double *. max_stiff is of type double *. min_damp is of type double *. max_damp is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1660, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1646, self, varargin{:});
     end
     function self = IImpedanceControl(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/IImpedanceControlRaw.m
+++ b/matlab/autogenerated/+yarp/IImpedanceControlRaw.m
@@ -7,7 +7,7 @@ classdef IImpedanceControlRaw < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1647, self);
+        yarpMEX(1633, self);
         self.SwigClear();
       end
     end
@@ -15,37 +15,37 @@ classdef IImpedanceControlRaw < SwigRef
     %Usage: retval = getAxes (ax)
     %
     %ax is of type int *. ax is of type int *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1648, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1634, self, varargin{:});
     end
     function varargout = getImpedanceRaw(self,varargin)
     %Usage: retval = getImpedanceRaw (j, stiffness, damping)
     %
     %j is of type int. stiffness is of type double *. damping is of type double *. j is of type int. stiffness is of type double *. damping is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1649, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1635, self, varargin{:});
     end
     function varargout = setImpedanceRaw(self,varargin)
     %Usage: retval = setImpedanceRaw (j, stiffness, damping)
     %
     %j is of type int. stiffness is of type double. damping is of type double. j is of type int. stiffness is of type double. damping is of type double. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1650, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1636, self, varargin{:});
     end
     function varargout = setImpedanceOffsetRaw(self,varargin)
     %Usage: retval = setImpedanceOffsetRaw (j, offset)
     %
     %j is of type int. offset is of type double. j is of type int. offset is of type double. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1651, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1637, self, varargin{:});
     end
     function varargout = getImpedanceOffsetRaw(self,varargin)
     %Usage: retval = getImpedanceOffsetRaw (j, offset)
     %
     %j is of type int. offset is of type double *. j is of type int. offset is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1652, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1638, self, varargin{:});
     end
     function varargout = getCurrentImpedanceLimitRaw(self,varargin)
     %Usage: retval = getCurrentImpedanceLimitRaw (j, min_stiff, max_stiff, min_damp, max_damp)
     %
     %j is of type int. min_stiff is of type double *. max_stiff is of type double *. min_damp is of type double *. max_damp is of type double *. j is of type int. min_stiff is of type double *. max_stiff is of type double *. min_damp is of type double *. max_damp is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1653, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1639, self, varargin{:});
     end
     function self = IImpedanceControlRaw(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/IMotorEncoders.m
+++ b/matlab/autogenerated/+yarp/IMotorEncoders.m
@@ -7,7 +7,7 @@ classdef IMotorEncoders < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1597, self);
+        yarpMEX(1583, self);
         self.SwigClear();
       end
     end
@@ -15,91 +15,91 @@ classdef IMotorEncoders < SwigRef
     %Usage: retval = resetMotorEncoder (m)
     %
     %m is of type int. m is of type int. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1598, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1584, self, varargin{:});
     end
     function varargout = resetMotorEncoders(self,varargin)
     %Usage: retval = resetMotorEncoders ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1599, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1585, self, varargin{:});
     end
     function varargout = setMotorEncoderCountsPerRevolution(self,varargin)
     %Usage: retval = setMotorEncoderCountsPerRevolution (m, cpr)
     %
     %m is of type int. cpr is of type double const. m is of type int. cpr is of type double const. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1600, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1586, self, varargin{:});
     end
     function varargout = getMotorEncoderCountsPerRevolution(self,varargin)
     %Usage: retval = getMotorEncoderCountsPerRevolution (m, cpr)
     %
     %m is of type int. cpr is of type double *. m is of type int. cpr is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1601, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1587, self, varargin{:});
     end
     function varargout = setMotorEncoder(self,varargin)
     %Usage: retval = setMotorEncoder (m, val)
     %
     %m is of type int. val is of type double const. m is of type int. val is of type double const. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1602, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1588, self, varargin{:});
     end
     function varargout = setMotorEncoders(self,varargin)
     %Usage: retval = setMotorEncoders (vals)
     %
     %vals is of type double const *. vals is of type double const *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1603, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1589, self, varargin{:});
     end
     function varargout = getMotorEncoderAcceleration(self,varargin)
     %Usage: retval = getMotorEncoderAcceleration (m, acc)
     %
     %m is of type int. acc is of type double *. m is of type int. acc is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1604, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1590, self, varargin{:});
     end
     function varargout = getMotorEncoderAccelerations(self,varargin)
     %Usage: retval = getMotorEncoderAccelerations (accs)
     %
     %accs is of type double *. accs is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1605, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1591, self, varargin{:});
     end
     function varargout = getNumberOfMotorEncoders(self,varargin)
     %Usage: retval = getNumberOfMotorEncoders ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(1606, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1592, self, varargin{:});
     end
     function varargout = getMotorEncoder(self,varargin)
     %Usage: retval = getMotorEncoder (j)
     %
     %j is of type int. j is of type int. retval is of type double. 
-      [varargout{1:nargout}] = yarpMEX(1607, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1593, self, varargin{:});
     end
     function varargout = getMotorEncoders(self,varargin)
     %Usage: retval = getMotorEncoders (encs)
     %
     %encs is of type DVector. encs is of type DVector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1608, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1594, self, varargin{:});
     end
     function varargout = getMotorEncoderTimed(self,varargin)
     %Usage: retval = getMotorEncoderTimed (j, enc, time)
     %
     %j is of type int. enc is of type DVector. time is of type DVector. j is of type int. enc is of type DVector. time is of type DVector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1609, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1595, self, varargin{:});
     end
     function varargout = getMotorEncodersTimed(self,varargin)
     %Usage: retval = getMotorEncodersTimed (encs, times)
     %
     %encs is of type DVector. times is of type DVector. encs is of type DVector. times is of type DVector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1610, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1596, self, varargin{:});
     end
     function varargout = getMotorEncoderSpeed(self,varargin)
     %Usage: retval = getMotorEncoderSpeed (j)
     %
     %j is of type int. j is of type int. retval is of type double. 
-      [varargout{1:nargout}] = yarpMEX(1611, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1597, self, varargin{:});
     end
     function varargout = getMotorEncoderSpeeds(self,varargin)
     %Usage: retval = getMotorEncoderSpeeds (speeds)
     %
     %speeds is of type DVector. speeds is of type DVector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1612, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1598, self, varargin{:});
     end
     function self = IMotorEncoders(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/IMotorEncodersRaw.m
+++ b/matlab/autogenerated/+yarp/IMotorEncodersRaw.m
@@ -7,7 +7,7 @@ classdef IMotorEncodersRaw < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1581, self);
+        yarpMEX(1567, self);
         self.SwigClear();
       end
     end
@@ -15,91 +15,91 @@ classdef IMotorEncodersRaw < SwigRef
     %Usage: retval = getNumberOfMotorEncodersRaw (num)
     %
     %num is of type int *. num is of type int *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1582, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1568, self, varargin{:});
     end
     function varargout = resetMotorEncoderRaw(self,varargin)
     %Usage: retval = resetMotorEncoderRaw (m)
     %
     %m is of type int. m is of type int. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1583, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1569, self, varargin{:});
     end
     function varargout = resetMotorEncodersRaw(self,varargin)
     %Usage: retval = resetMotorEncodersRaw ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1584, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1570, self, varargin{:});
     end
     function varargout = setMotorEncoderCountsPerRevolutionRaw(self,varargin)
     %Usage: retval = setMotorEncoderCountsPerRevolutionRaw (m, cpr)
     %
     %m is of type int. cpr is of type double const. m is of type int. cpr is of type double const. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1585, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1571, self, varargin{:});
     end
     function varargout = getMotorEncoderCountsPerRevolutionRaw(self,varargin)
     %Usage: retval = getMotorEncoderCountsPerRevolutionRaw (m, cpr)
     %
     %m is of type int. cpr is of type double *. m is of type int. cpr is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1586, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1572, self, varargin{:});
     end
     function varargout = setMotorEncoderRaw(self,varargin)
     %Usage: retval = setMotorEncoderRaw (m, val)
     %
     %m is of type int. val is of type double const. m is of type int. val is of type double const. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1587, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1573, self, varargin{:});
     end
     function varargout = setMotorEncodersRaw(self,varargin)
     %Usage: retval = setMotorEncodersRaw (vals)
     %
     %vals is of type double const *. vals is of type double const *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1588, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1574, self, varargin{:});
     end
     function varargout = getMotorEncoderRaw(self,varargin)
     %Usage: retval = getMotorEncoderRaw (m, v)
     %
     %m is of type int. v is of type double *. m is of type int. v is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1589, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1575, self, varargin{:});
     end
     function varargout = getMotorEncodersRaw(self,varargin)
     %Usage: retval = getMotorEncodersRaw (encs)
     %
     %encs is of type double *. encs is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1590, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1576, self, varargin{:});
     end
     function varargout = getMotorEncodersTimedRaw(self,varargin)
     %Usage: retval = getMotorEncodersTimedRaw (encs, stamps)
     %
     %encs is of type double *. stamps is of type double *. encs is of type double *. stamps is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1591, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1577, self, varargin{:});
     end
     function varargout = getMotorEncoderTimedRaw(self,varargin)
     %Usage: retval = getMotorEncoderTimedRaw (m, encs, stamp)
     %
     %m is of type int. encs is of type double *. stamp is of type double *. m is of type int. encs is of type double *. stamp is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1592, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1578, self, varargin{:});
     end
     function varargout = getMotorEncoderSpeedRaw(self,varargin)
     %Usage: retval = getMotorEncoderSpeedRaw (m, sp)
     %
     %m is of type int. sp is of type double *. m is of type int. sp is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1593, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1579, self, varargin{:});
     end
     function varargout = getMotorEncoderSpeedsRaw(self,varargin)
     %Usage: retval = getMotorEncoderSpeedsRaw (spds)
     %
     %spds is of type double *. spds is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1594, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1580, self, varargin{:});
     end
     function varargout = getMotorEncoderAccelerationRaw(self,varargin)
     %Usage: retval = getMotorEncoderAccelerationRaw (m, spds)
     %
     %m is of type int. spds is of type double *. m is of type int. spds is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1595, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1581, self, varargin{:});
     end
     function varargout = getMotorEncoderAccelerationsRaw(self,varargin)
     %Usage: retval = getMotorEncoderAccelerationsRaw (accs)
     %
     %accs is of type double *. accs is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1596, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1582, self, varargin{:});
     end
     function self = IMotorEncodersRaw(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/IPWMControl.m
+++ b/matlab/autogenerated/+yarp/IPWMControl.m
@@ -7,7 +7,7 @@ classdef IPWMControl < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1681, self);
+        yarpMEX(1667, self);
         self.SwigClear();
       end
     end
@@ -15,43 +15,43 @@ classdef IPWMControl < SwigRef
     %Usage: retval = getNumberOfMotors (number)
     %
     %number is of type int *. number is of type int *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1682, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1668, self, varargin{:});
     end
     function varargout = setRefDutyCycle(self,varargin)
     %Usage: retval = setRefDutyCycle (m, ref)
     %
     %m is of type int. ref is of type double. m is of type int. ref is of type double. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1683, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1669, self, varargin{:});
     end
     function varargout = setRefDutyCycles(self,varargin)
     %Usage: retval = setRefDutyCycles (refs)
     %
     %refs is of type double const *. refs is of type double const *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1684, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1670, self, varargin{:});
     end
     function varargout = getRefDutyCycle(self,varargin)
     %Usage: retval = getRefDutyCycle (m, ref)
     %
     %m is of type int. ref is of type double *. m is of type int. ref is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1685, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1671, self, varargin{:});
     end
     function varargout = getRefDutyCycles(self,varargin)
     %Usage: retval = getRefDutyCycles (refs)
     %
     %refs is of type double *. refs is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1686, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1672, self, varargin{:});
     end
     function varargout = getDutyCycle(self,varargin)
     %Usage: retval = getDutyCycle (m, val)
     %
     %m is of type int. val is of type double *. m is of type int. val is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1687, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1673, self, varargin{:});
     end
     function varargout = getDutyCycles(self,varargin)
     %Usage: retval = getDutyCycles (vals)
     %
     %vals is of type double *. vals is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1688, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1674, self, varargin{:});
     end
     function self = IPWMControl(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/IPWMControlRaw.m
+++ b/matlab/autogenerated/+yarp/IPWMControlRaw.m
@@ -7,7 +7,7 @@ classdef IPWMControlRaw < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1689, self);
+        yarpMEX(1675, self);
         self.SwigClear();
       end
     end
@@ -15,43 +15,43 @@ classdef IPWMControlRaw < SwigRef
     %Usage: retval = getNumberOfMotorsRaw (number)
     %
     %number is of type int *. number is of type int *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1690, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1676, self, varargin{:});
     end
     function varargout = setRefDutyCycleRaw(self,varargin)
     %Usage: retval = setRefDutyCycleRaw (m, ref)
     %
     %m is of type int. ref is of type double. m is of type int. ref is of type double. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1691, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1677, self, varargin{:});
     end
     function varargout = setRefDutyCyclesRaw(self,varargin)
     %Usage: retval = setRefDutyCyclesRaw (refs)
     %
     %refs is of type double const *. refs is of type double const *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1692, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1678, self, varargin{:});
     end
     function varargout = getRefDutyCycleRaw(self,varargin)
     %Usage: retval = getRefDutyCycleRaw (m, ref)
     %
     %m is of type int. ref is of type double *. m is of type int. ref is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1693, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1679, self, varargin{:});
     end
     function varargout = getRefDutyCyclesRaw(self,varargin)
     %Usage: retval = getRefDutyCyclesRaw (refs)
     %
     %refs is of type double *. refs is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1694, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1680, self, varargin{:});
     end
     function varargout = getDutyCycleRaw(self,varargin)
     %Usage: retval = getDutyCycleRaw (m, val)
     %
     %m is of type int. val is of type double *. m is of type int. val is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1695, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1681, self, varargin{:});
     end
     function varargout = getDutyCyclesRaw(self,varargin)
     %Usage: retval = getDutyCyclesRaw (vals)
     %
     %vals is of type double *. vals is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1696, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1682, self, varargin{:});
     end
     function self = IPWMControlRaw(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/IPidControl.m
+++ b/matlab/autogenerated/+yarp/IPidControl.m
@@ -7,7 +7,7 @@ classdef IPidControl < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1753, self);
+        yarpMEX(1739, self);
         self.SwigClear();
       end
     end
@@ -15,127 +15,127 @@ classdef IPidControl < SwigRef
     %Usage: retval = setPid (pidtype, j, pid)
     %
     %pidtype is of type PidControlTypeEnum const &. j is of type int. pid is of type Pid. pidtype is of type PidControlTypeEnum const &. j is of type int. pid is of type Pid. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1754, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1740, self, varargin{:});
     end
     function varargout = setPids(self,varargin)
     %Usage: retval = setPids (pidtype, pids)
     %
     %pidtype is of type PidControlTypeEnum const &. pids is of type Pid. pidtype is of type PidControlTypeEnum const &. pids is of type Pid. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1755, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1741, self, varargin{:});
     end
     function varargout = setPidReference(self,varargin)
     %Usage: retval = setPidReference (pidtype, j, ref)
     %
     %pidtype is of type PidControlTypeEnum const &. j is of type int. ref is of type double. pidtype is of type PidControlTypeEnum const &. j is of type int. ref is of type double. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1756, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1742, self, varargin{:});
     end
     function varargout = setPidReferences(self,varargin)
     %Usage: retval = setPidReferences (pidtype, refs)
     %
     %pidtype is of type PidControlTypeEnum const &. refs is of type double const *. pidtype is of type PidControlTypeEnum const &. refs is of type double const *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1757, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1743, self, varargin{:});
     end
     function varargout = setPidErrorLimit(self,varargin)
     %Usage: retval = setPidErrorLimit (pidtype, j, limit)
     %
     %pidtype is of type PidControlTypeEnum const &. j is of type int. limit is of type double. pidtype is of type PidControlTypeEnum const &. j is of type int. limit is of type double. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1758, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1744, self, varargin{:});
     end
     function varargout = setPidErrorLimits(self,varargin)
     %Usage: retval = setPidErrorLimits (pidtype, limits)
     %
     %pidtype is of type PidControlTypeEnum const &. limits is of type double const *. pidtype is of type PidControlTypeEnum const &. limits is of type double const *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1759, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1745, self, varargin{:});
     end
     function varargout = getPidError(self,varargin)
     %Usage: retval = getPidError (pidtype, j, err)
     %
     %pidtype is of type PidControlTypeEnum const &. j is of type int. err is of type double *. pidtype is of type PidControlTypeEnum const &. j is of type int. err is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1760, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1746, self, varargin{:});
     end
     function varargout = getPidErrors(self,varargin)
     %Usage: retval = getPidErrors (pidtype, errs)
     %
     %pidtype is of type PidControlTypeEnum const &. errs is of type double *. pidtype is of type PidControlTypeEnum const &. errs is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1761, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1747, self, varargin{:});
     end
     function varargout = getPidOutput(self,varargin)
     %Usage: retval = getPidOutput (pidtype, j, out)
     %
     %pidtype is of type PidControlTypeEnum const &. j is of type int. out is of type double *. pidtype is of type PidControlTypeEnum const &. j is of type int. out is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1762, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1748, self, varargin{:});
     end
     function varargout = getPidOutputs(self,varargin)
     %Usage: retval = getPidOutputs (pidtype, outs)
     %
     %pidtype is of type PidControlTypeEnum const &. outs is of type double *. pidtype is of type PidControlTypeEnum const &. outs is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1763, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1749, self, varargin{:});
     end
     function varargout = getPid(self,varargin)
     %Usage: retval = getPid (pidtype, j, pid)
     %
     %pidtype is of type PidControlTypeEnum const &. j is of type int. pid is of type Pid. pidtype is of type PidControlTypeEnum const &. j is of type int. pid is of type Pid. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1764, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1750, self, varargin{:});
     end
     function varargout = getPids(self,varargin)
     %Usage: retval = getPids (pidtype, pids)
     %
     %pidtype is of type PidControlTypeEnum const &. pids is of type Pid. pidtype is of type PidControlTypeEnum const &. pids is of type Pid. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1765, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1751, self, varargin{:});
     end
     function varargout = getPidReference(self,varargin)
     %Usage: retval = getPidReference (pidtype, j, ref)
     %
     %pidtype is of type PidControlTypeEnum const &. j is of type int. ref is of type double *. pidtype is of type PidControlTypeEnum const &. j is of type int. ref is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1766, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1752, self, varargin{:});
     end
     function varargout = getPidReferences(self,varargin)
     %Usage: retval = getPidReferences (pidtype, refs)
     %
     %pidtype is of type PidControlTypeEnum const &. refs is of type double *. pidtype is of type PidControlTypeEnum const &. refs is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1767, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1753, self, varargin{:});
     end
     function varargout = getPidErrorLimit(self,varargin)
     %Usage: retval = getPidErrorLimit (pidtype, j, limit)
     %
     %pidtype is of type PidControlTypeEnum const &. j is of type int. limit is of type double *. pidtype is of type PidControlTypeEnum const &. j is of type int. limit is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1768, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1754, self, varargin{:});
     end
     function varargout = getPidErrorLimits(self,varargin)
     %Usage: retval = getPidErrorLimits (pidtype, limits)
     %
     %pidtype is of type PidControlTypeEnum const &. limits is of type double *. pidtype is of type PidControlTypeEnum const &. limits is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1769, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1755, self, varargin{:});
     end
     function varargout = resetPid(self,varargin)
     %Usage: retval = resetPid (pidtype, j)
     %
     %pidtype is of type PidControlTypeEnum const &. j is of type int. pidtype is of type PidControlTypeEnum const &. j is of type int. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1770, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1756, self, varargin{:});
     end
     function varargout = disablePid(self,varargin)
     %Usage: retval = disablePid (pidtype, j)
     %
     %pidtype is of type PidControlTypeEnum const &. j is of type int. pidtype is of type PidControlTypeEnum const &. j is of type int. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1771, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1757, self, varargin{:});
     end
     function varargout = enablePid(self,varargin)
     %Usage: retval = enablePid (pidtype, j)
     %
     %pidtype is of type PidControlTypeEnum const &. j is of type int. pidtype is of type PidControlTypeEnum const &. j is of type int. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1772, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1758, self, varargin{:});
     end
     function varargout = setPidOffset(self,varargin)
     %Usage: retval = setPidOffset (pidtype, j, v)
     %
     %pidtype is of type PidControlTypeEnum const &. j is of type int. v is of type double. pidtype is of type PidControlTypeEnum const &. j is of type int. v is of type double. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1773, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1759, self, varargin{:});
     end
     function varargout = isPidEnabled(self,varargin)
     %Usage: retval = isPidEnabled (pidtype, j, enabled)
     %
     %pidtype is of type PidControlTypeEnum const &. j is of type int. enabled is of type bool *. pidtype is of type PidControlTypeEnum const &. j is of type int. enabled is of type bool *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1774, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1760, self, varargin{:});
     end
     function self = IPidControl(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/IPidControlRaw.m
+++ b/matlab/autogenerated/+yarp/IPidControlRaw.m
@@ -7,7 +7,7 @@ classdef IPidControlRaw < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1731, self);
+        yarpMEX(1717, self);
         self.SwigClear();
       end
     end
@@ -15,127 +15,127 @@ classdef IPidControlRaw < SwigRef
     %Usage: retval = setPidRaw (pidtype, j, pid)
     %
     %pidtype is of type PidControlTypeEnum const &. j is of type int. pid is of type Pid. pidtype is of type PidControlTypeEnum const &. j is of type int. pid is of type Pid. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1732, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1718, self, varargin{:});
     end
     function varargout = setPidsRaw(self,varargin)
     %Usage: retval = setPidsRaw (pidtype, pids)
     %
     %pidtype is of type PidControlTypeEnum const &. pids is of type Pid. pidtype is of type PidControlTypeEnum const &. pids is of type Pid. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1733, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1719, self, varargin{:});
     end
     function varargout = setPidReferenceRaw(self,varargin)
     %Usage: retval = setPidReferenceRaw (pidtype, j, ref)
     %
     %pidtype is of type PidControlTypeEnum const &. j is of type int. ref is of type double. pidtype is of type PidControlTypeEnum const &. j is of type int. ref is of type double. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1734, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1720, self, varargin{:});
     end
     function varargout = setPidReferencesRaw(self,varargin)
     %Usage: retval = setPidReferencesRaw (pidtype, refs)
     %
     %pidtype is of type PidControlTypeEnum const &. refs is of type double const *. pidtype is of type PidControlTypeEnum const &. refs is of type double const *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1735, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1721, self, varargin{:});
     end
     function varargout = setPidErrorLimitRaw(self,varargin)
     %Usage: retval = setPidErrorLimitRaw (pidtype, j, limit)
     %
     %pidtype is of type PidControlTypeEnum const &. j is of type int. limit is of type double. pidtype is of type PidControlTypeEnum const &. j is of type int. limit is of type double. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1736, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1722, self, varargin{:});
     end
     function varargout = setPidErrorLimitsRaw(self,varargin)
     %Usage: retval = setPidErrorLimitsRaw (pidtype, limits)
     %
     %pidtype is of type PidControlTypeEnum const &. limits is of type double const *. pidtype is of type PidControlTypeEnum const &. limits is of type double const *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1737, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1723, self, varargin{:});
     end
     function varargout = getPidErrorRaw(self,varargin)
     %Usage: retval = getPidErrorRaw (pidtype, j, err)
     %
     %pidtype is of type PidControlTypeEnum const &. j is of type int. err is of type double *. pidtype is of type PidControlTypeEnum const &. j is of type int. err is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1738, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1724, self, varargin{:});
     end
     function varargout = getPidErrorsRaw(self,varargin)
     %Usage: retval = getPidErrorsRaw (pidtype, errs)
     %
     %pidtype is of type PidControlTypeEnum const &. errs is of type double *. pidtype is of type PidControlTypeEnum const &. errs is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1739, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1725, self, varargin{:});
     end
     function varargout = getPidOutputRaw(self,varargin)
     %Usage: retval = getPidOutputRaw (pidtype, j, out)
     %
     %pidtype is of type PidControlTypeEnum const &. j is of type int. out is of type double *. pidtype is of type PidControlTypeEnum const &. j is of type int. out is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1740, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1726, self, varargin{:});
     end
     function varargout = getPidOutputsRaw(self,varargin)
     %Usage: retval = getPidOutputsRaw (pidtype, outs)
     %
     %pidtype is of type PidControlTypeEnum const &. outs is of type double *. pidtype is of type PidControlTypeEnum const &. outs is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1741, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1727, self, varargin{:});
     end
     function varargout = getPidRaw(self,varargin)
     %Usage: retval = getPidRaw (pidtype, j, pid)
     %
     %pidtype is of type PidControlTypeEnum const &. j is of type int. pid is of type Pid. pidtype is of type PidControlTypeEnum const &. j is of type int. pid is of type Pid. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1742, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1728, self, varargin{:});
     end
     function varargout = getPidsRaw(self,varargin)
     %Usage: retval = getPidsRaw (pidtype, pids)
     %
     %pidtype is of type PidControlTypeEnum const &. pids is of type Pid. pidtype is of type PidControlTypeEnum const &. pids is of type Pid. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1743, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1729, self, varargin{:});
     end
     function varargout = getPidReferenceRaw(self,varargin)
     %Usage: retval = getPidReferenceRaw (pidtype, j, ref)
     %
     %pidtype is of type PidControlTypeEnum const &. j is of type int. ref is of type double *. pidtype is of type PidControlTypeEnum const &. j is of type int. ref is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1744, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1730, self, varargin{:});
     end
     function varargout = getPidReferencesRaw(self,varargin)
     %Usage: retval = getPidReferencesRaw (pidtype, refs)
     %
     %pidtype is of type PidControlTypeEnum const &. refs is of type double *. pidtype is of type PidControlTypeEnum const &. refs is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1745, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1731, self, varargin{:});
     end
     function varargout = getPidErrorLimitRaw(self,varargin)
     %Usage: retval = getPidErrorLimitRaw (pidtype, j, limit)
     %
     %pidtype is of type PidControlTypeEnum const &. j is of type int. limit is of type double *. pidtype is of type PidControlTypeEnum const &. j is of type int. limit is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1746, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1732, self, varargin{:});
     end
     function varargout = getPidErrorLimitsRaw(self,varargin)
     %Usage: retval = getPidErrorLimitsRaw (pidtype, limits)
     %
     %pidtype is of type PidControlTypeEnum const &. limits is of type double *. pidtype is of type PidControlTypeEnum const &. limits is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1747, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1733, self, varargin{:});
     end
     function varargout = resetPidRaw(self,varargin)
     %Usage: retval = resetPidRaw (pidtype, j)
     %
     %pidtype is of type PidControlTypeEnum const &. j is of type int. pidtype is of type PidControlTypeEnum const &. j is of type int. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1748, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1734, self, varargin{:});
     end
     function varargout = disablePidRaw(self,varargin)
     %Usage: retval = disablePidRaw (pidtype, j)
     %
     %pidtype is of type PidControlTypeEnum const &. j is of type int. pidtype is of type PidControlTypeEnum const &. j is of type int. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1749, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1735, self, varargin{:});
     end
     function varargout = enablePidRaw(self,varargin)
     %Usage: retval = enablePidRaw (pidtype, j)
     %
     %pidtype is of type PidControlTypeEnum const &. j is of type int. pidtype is of type PidControlTypeEnum const &. j is of type int. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1750, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1736, self, varargin{:});
     end
     function varargout = setPidOffsetRaw(self,varargin)
     %Usage: retval = setPidOffsetRaw (pidtype, j, v)
     %
     %pidtype is of type PidControlTypeEnum const &. j is of type int. v is of type double. pidtype is of type PidControlTypeEnum const &. j is of type int. v is of type double. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1751, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1737, self, varargin{:});
     end
     function varargout = isPidEnabledRaw(self,varargin)
     %Usage: retval = isPidEnabledRaw (pidtype, j, enabled)
     %
     %pidtype is of type PidControlTypeEnum const &. j is of type int. enabled is of type bool *. pidtype is of type PidControlTypeEnum const &. j is of type int. enabled is of type bool *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1752, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1738, self, varargin{:});
     end
     function self = IPidControlRaw(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/IPositionControl.m
+++ b/matlab/autogenerated/+yarp/IPositionControl.m
@@ -7,7 +7,7 @@ classdef IPositionControl < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1512, self);
+        yarpMEX(1498, self);
         self.SwigClear();
       end
     end
@@ -15,97 +15,97 @@ classdef IPositionControl < SwigRef
     %Usage: retval = setRefSpeed (j, sp)
     %
     %j is of type int. sp is of type double. j is of type int. sp is of type double. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1513, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1499, self, varargin{:});
     end
     function varargout = setRefAcceleration(self,varargin)
     %Usage: retval = setRefAcceleration (j, acc)
     %
     %j is of type int. acc is of type double. j is of type int. acc is of type double. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1514, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1500, self, varargin{:});
     end
     function varargout = setRefAccelerations(self,varargin)
     %Usage: retval = setRefAccelerations (n_joint, joints, accs)
     %
     %n_joint is of type int const. joints is of type int const *. accs is of type double const *. n_joint is of type int const. joints is of type int const *. accs is of type double const *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1515, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1501, self, varargin{:});
     end
     function varargout = stop(self,varargin)
     %Usage: retval = stop (n_joint, joints)
     %
     %n_joint is of type int const. joints is of type int const *. n_joint is of type int const. joints is of type int const *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1516, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1502, self, varargin{:});
     end
     function varargout = getTargetPosition(self,varargin)
     %Usage: retval = getTargetPosition (joint, ref)
     %
     %joint is of type int const. ref is of type double *. joint is of type int const. ref is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1517, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1503, self, varargin{:});
     end
     function varargout = getTargetPositions(self,varargin)
     %Usage: retval = getTargetPositions (n_joint, joints, refs)
     %
     %n_joint is of type int const. joints is of type int const *. refs is of type double *. n_joint is of type int const. joints is of type int const *. refs is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1518, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1504, self, varargin{:});
     end
     function varargout = getAxes(self,varargin)
     %Usage: retval = getAxes ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(1519, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1505, self, varargin{:});
     end
     function varargout = positionMove(self,varargin)
     %Usage: retval = positionMove (data)
     %
     %data is of type DVector. data is of type DVector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1520, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1506, self, varargin{:});
     end
     function varargout = relativeMove(self,varargin)
     %Usage: retval = relativeMove (data)
     %
     %data is of type DVector. data is of type DVector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1521, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1507, self, varargin{:});
     end
     function varargout = setRefSpeeds(self,varargin)
     %Usage: retval = setRefSpeeds (data)
     %
     %data is of type DVector. data is of type DVector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1522, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1508, self, varargin{:});
     end
     function varargout = getRefSpeed(self,varargin)
     %Usage: retval = getRefSpeed (j, data)
     %
     %j is of type int. data is of type DVector. j is of type int. data is of type DVector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1523, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1509, self, varargin{:});
     end
     function varargout = getRefSpeeds(self,varargin)
     %Usage: retval = getRefSpeeds (data)
     %
     %data is of type DVector. data is of type DVector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1524, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1510, self, varargin{:});
     end
     function varargout = getRefAcceleration(self,varargin)
     %Usage: retval = getRefAcceleration (j, data)
     %
     %j is of type int. data is of type DVector. j is of type int. data is of type DVector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1525, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1511, self, varargin{:});
     end
     function varargout = getRefAccelerations(self,varargin)
     %Usage: retval = getRefAccelerations (data)
     %
     %data is of type DVector. data is of type DVector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1526, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1512, self, varargin{:});
     end
     function varargout = checkMotionDone(self,varargin)
     %Usage: retval = checkMotionDone (i, flag)
     %
     %i is of type int. flag is of type BVector. i is of type int. flag is of type BVector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1527, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1513, self, varargin{:});
     end
     function varargout = isMotionDone(self,varargin)
     %Usage: retval = isMotionDone ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1528, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1514, self, varargin{:});
     end
     function self = IPositionControl(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/IPositionControlRaw.m
+++ b/matlab/autogenerated/+yarp/IPositionControlRaw.m
@@ -7,7 +7,7 @@ classdef IPositionControlRaw < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1496, self);
+        yarpMEX(1482, self);
         self.SwigClear();
       end
     end
@@ -15,91 +15,91 @@ classdef IPositionControlRaw < SwigRef
     %Usage: retval = getAxes (ax)
     %
     %ax is of type int *. ax is of type int *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1497, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1483, self, varargin{:});
     end
     function varargout = setRefSpeedRaw(self,varargin)
     %Usage: retval = setRefSpeedRaw (j, sp)
     %
     %j is of type int. sp is of type double. j is of type int. sp is of type double. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1498, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1484, self, varargin{:});
     end
     function varargout = setRefAccelerationRaw(self,varargin)
     %Usage: retval = setRefAccelerationRaw (j, acc)
     %
     %j is of type int. acc is of type double. j is of type int. acc is of type double. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1499, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1485, self, varargin{:});
     end
     function varargout = getRefSpeedRaw(self,varargin)
     %Usage: retval = getRefSpeedRaw (j, ref)
     %
     %j is of type int. ref is of type double *. j is of type int. ref is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1500, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1486, self, varargin{:});
     end
     function varargout = getRefAccelerationRaw(self,varargin)
     %Usage: retval = getRefAccelerationRaw (j, acc)
     %
     %j is of type int. acc is of type double *. j is of type int. acc is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1501, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1487, self, varargin{:});
     end
     function varargout = positionMoveRaw(self,varargin)
     %Usage: retval = positionMoveRaw (n_joint, joints, refs)
     %
     %n_joint is of type int const. joints is of type int const *. refs is of type double const *. n_joint is of type int const. joints is of type int const *. refs is of type double const *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1502, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1488, self, varargin{:});
     end
     function varargout = relativeMoveRaw(self,varargin)
     %Usage: retval = relativeMoveRaw (n_joint, joints, deltas)
     %
     %n_joint is of type int const. joints is of type int const *. deltas is of type double const *. n_joint is of type int const. joints is of type int const *. deltas is of type double const *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1503, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1489, self, varargin{:});
     end
     function varargout = checkMotionDoneRaw(self,varargin)
     %Usage: retval = checkMotionDoneRaw (n_joint, joints, flags)
     %
     %n_joint is of type int const. joints is of type int const *. flags is of type bool *. n_joint is of type int const. joints is of type int const *. flags is of type bool *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1504, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1490, self, varargin{:});
     end
     function varargout = setRefSpeedsRaw(self,varargin)
     %Usage: retval = setRefSpeedsRaw (n_joint, joints, spds)
     %
     %n_joint is of type int const. joints is of type int const *. spds is of type double const *. n_joint is of type int const. joints is of type int const *. spds is of type double const *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1505, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1491, self, varargin{:});
     end
     function varargout = setRefAccelerationsRaw(self,varargin)
     %Usage: retval = setRefAccelerationsRaw (n_joint, joints, accs)
     %
     %n_joint is of type int const. joints is of type int const *. accs is of type double const *. n_joint is of type int const. joints is of type int const *. accs is of type double const *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1506, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1492, self, varargin{:});
     end
     function varargout = getRefSpeedsRaw(self,varargin)
     %Usage: retval = getRefSpeedsRaw (n_joint, joints, spds)
     %
     %n_joint is of type int const. joints is of type int const *. spds is of type double *. n_joint is of type int const. joints is of type int const *. spds is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1507, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1493, self, varargin{:});
     end
     function varargout = getRefAccelerationsRaw(self,varargin)
     %Usage: retval = getRefAccelerationsRaw (n_joint, joints, accs)
     %
     %n_joint is of type int const. joints is of type int const *. accs is of type double *. n_joint is of type int const. joints is of type int const *. accs is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1508, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1494, self, varargin{:});
     end
     function varargout = stopRaw(self,varargin)
     %Usage: retval = stopRaw (n_joint, joints)
     %
     %n_joint is of type int const. joints is of type int const *. n_joint is of type int const. joints is of type int const *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1509, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1495, self, varargin{:});
     end
     function varargout = getTargetPositionRaw(self,varargin)
     %Usage: retval = getTargetPositionRaw (joint, ref)
     %
     %joint is of type int const. ref is of type double *. joint is of type int const. ref is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1510, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1496, self, varargin{:});
     end
     function varargout = getTargetPositionsRaw(self,varargin)
     %Usage: retval = getTargetPositionsRaw (n_joint, joints, refs)
     %
     %n_joint is of type int const. joints is of type int const *. refs is of type double *. n_joint is of type int const. joints is of type int const *. refs is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1511, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1497, self, varargin{:});
     end
     function self = IPositionControlRaw(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/IPositionDirect.m
+++ b/matlab/autogenerated/+yarp/IPositionDirect.m
@@ -7,7 +7,7 @@ classdef IPositionDirect < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1775, self);
+        yarpMEX(1761, self);
         self.SwigClear();
       end
     end
@@ -15,31 +15,31 @@ classdef IPositionDirect < SwigRef
     %Usage: retval = setPosition (j, ref)
     %
     %j is of type int. ref is of type double. j is of type int. ref is of type double. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1776, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1762, self, varargin{:});
     end
     function varargout = getRefPosition(self,varargin)
     %Usage: retval = getRefPosition (joint, ref)
     %
     %joint is of type int const. ref is of type double *. joint is of type int const. ref is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1777, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1763, self, varargin{:});
     end
     function varargout = getRefPositions(self,varargin)
     %Usage: retval = getRefPositions (n_joint, joints, refs)
     %
     %n_joint is of type int const. joints is of type int const *. refs is of type double *. n_joint is of type int const. joints is of type int const *. refs is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1778, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1764, self, varargin{:});
     end
     function varargout = getAxes(self,varargin)
     %Usage: retval = getAxes ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(1779, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1765, self, varargin{:});
     end
     function varargout = setPositions(self,varargin)
     %Usage: retval = setPositions (data)
     %
     %data is of type DVector. data is of type DVector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1780, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1766, self, varargin{:});
     end
     function self = IPositionDirect(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/IPositionDirectRaw.m
+++ b/matlab/autogenerated/+yarp/IPositionDirectRaw.m
@@ -7,7 +7,7 @@ classdef IPositionDirectRaw < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1781, self);
+        yarpMEX(1767, self);
         self.SwigClear();
       end
     end
@@ -15,31 +15,31 @@ classdef IPositionDirectRaw < SwigRef
     %Usage: retval = getAxes (axes)
     %
     %axes is of type int *. axes is of type int *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1782, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1768, self, varargin{:});
     end
     function varargout = setPositionRaw(self,varargin)
     %Usage: retval = setPositionRaw (j, ref)
     %
     %j is of type int. ref is of type double. j is of type int. ref is of type double. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1783, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1769, self, varargin{:});
     end
     function varargout = setPositionsRaw(self,varargin)
     %Usage: retval = setPositionsRaw (refs)
     %
     %refs is of type double const *. refs is of type double const *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1784, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1770, self, varargin{:});
     end
     function varargout = getRefPositionRaw(self,varargin)
     %Usage: retval = getRefPositionRaw (joint, ref)
     %
     %joint is of type int const. ref is of type double *. joint is of type int const. ref is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1785, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1771, self, varargin{:});
     end
     function varargout = getRefPositionsRaw(self,varargin)
     %Usage: retval = getRefPositionsRaw (n_joint, joints, refs)
     %
     %n_joint is of type int const. joints is of type int const *. refs is of type double *. n_joint is of type int const. joints is of type int const *. refs is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1786, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1772, self, varargin{:});
     end
     function self = IPositionDirectRaw(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/IRemoteCalibrator.m
+++ b/matlab/autogenerated/+yarp/IRemoteCalibrator.m
@@ -7,7 +7,7 @@ classdef IRemoteCalibrator < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1558, self);
+        yarpMEX(1544, self);
         self.SwigClear();
       end
     end
@@ -15,72 +15,72 @@ classdef IRemoteCalibrator < SwigRef
     %Usage: retval = setCalibratorDevice (dev)
     %
     %dev is of type IRemoteCalibrator. dev is of type IRemoteCalibrator. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1559, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1545, self, varargin{:});
     end
     function varargout = getCalibratorDevice(self,varargin)
     %Usage: retval = getCalibratorDevice ()
     %
     %retval is of type IRemoteCalibrator. 
-      [varargout{1:nargout}] = yarpMEX(1560, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1546, self, varargin{:});
     end
     function varargout = isCalibratorDevicePresent(self,varargin)
     %Usage: retval = isCalibratorDevicePresent (isCalib)
     %
     %isCalib is of type bool *. isCalib is of type bool *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1561, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1547, self, varargin{:});
     end
     function varargout = releaseCalibratorDevice(self,varargin)
     %Usage: releaseCalibratorDevice ()
     %
-      [varargout{1:nargout}] = yarpMEX(1562, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1548, self, varargin{:});
     end
     function varargout = calibrateSingleJoint(self,varargin)
     %Usage: retval = calibrateSingleJoint (j)
     %
     %j is of type int. j is of type int. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1563, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1549, self, varargin{:});
     end
     function varargout = calibrateWholePart(self,varargin)
     %Usage: retval = calibrateWholePart ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1564, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1550, self, varargin{:});
     end
     function varargout = homingSingleJoint(self,varargin)
     %Usage: retval = homingSingleJoint (j)
     %
     %j is of type int. j is of type int. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1565, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1551, self, varargin{:});
     end
     function varargout = homingWholePart(self,varargin)
     %Usage: retval = homingWholePart ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1566, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1552, self, varargin{:});
     end
     function varargout = parkSingleJoint(self,varargin)
     %Usage: retval = parkSingleJoint (j)
     %
     %j is of type int. j is of type int. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1567, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1553, self, varargin{:});
     end
     function varargout = parkWholePart(self,varargin)
     %Usage: retval = parkWholePart ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1568, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1554, self, varargin{:});
     end
     function varargout = quitCalibrate(self,varargin)
     %Usage: retval = quitCalibrate ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1569, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1555, self, varargin{:});
     end
     function varargout = quitPark(self,varargin)
     %Usage: retval = quitPark ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1570, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1556, self, varargin{:});
     end
     function self = IRemoteCalibrator(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/IRemoteVariables.m
+++ b/matlab/autogenerated/+yarp/IRemoteVariables.m
@@ -7,7 +7,7 @@ classdef IRemoteVariables < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1727, self);
+        yarpMEX(1713, self);
         self.SwigClear();
       end
     end
@@ -15,19 +15,19 @@ classdef IRemoteVariables < SwigRef
     %Usage: retval = getRemoteVariable (key, val)
     %
     %key is of type std::string. val is of type Bottle. key is of type std::string. val is of type Bottle. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1728, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1714, self, varargin{:});
     end
     function varargout = setRemoteVariable(self,varargin)
     %Usage: retval = setRemoteVariable (key, val)
     %
     %key is of type std::string. val is of type Bottle. key is of type std::string. val is of type Bottle. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1729, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1715, self, varargin{:});
     end
     function varargout = getRemoteVariablesList(self,varargin)
     %Usage: retval = getRemoteVariablesList (listOfKeys)
     %
     %listOfKeys is of type Bottle. listOfKeys is of type Bottle. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1730, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1716, self, varargin{:});
     end
     function self = IRemoteVariables(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/IRemoteVariablesRaw.m
+++ b/matlab/autogenerated/+yarp/IRemoteVariablesRaw.m
@@ -7,7 +7,7 @@ classdef IRemoteVariablesRaw < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1723, self);
+        yarpMEX(1709, self);
         self.SwigClear();
       end
     end
@@ -15,19 +15,19 @@ classdef IRemoteVariablesRaw < SwigRef
     %Usage: retval = getRemoteVariableRaw (key, val)
     %
     %key is of type std::string. val is of type Bottle. key is of type std::string. val is of type Bottle. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1724, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1710, self, varargin{:});
     end
     function varargout = setRemoteVariableRaw(self,varargin)
     %Usage: retval = setRemoteVariableRaw (key, val)
     %
     %key is of type std::string. val is of type Bottle. key is of type std::string. val is of type Bottle. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1725, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1711, self, varargin{:});
     end
     function varargout = getRemoteVariablesListRaw(self,varargin)
     %Usage: retval = getRemoteVariablesListRaw (listOfKeys)
     %
     %listOfKeys is of type Bottle. listOfKeys is of type Bottle. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1726, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1712, self, varargin{:});
     end
     function self = IRemoteVariablesRaw(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/ITorqueControl.m
+++ b/matlab/autogenerated/+yarp/ITorqueControl.m
@@ -7,7 +7,7 @@ classdef ITorqueControl < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1623, self);
+        yarpMEX(1609, self);
         self.SwigClear();
       end
     end
@@ -15,67 +15,67 @@ classdef ITorqueControl < SwigRef
     %Usage: retval = getAxes (ax)
     %
     %ax is of type int *. ax is of type int *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1624, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1610, self, varargin{:});
     end
     function varargout = getRefTorques(self,varargin)
     %Usage: retval = getRefTorques (t)
     %
     %t is of type double *. t is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1625, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1611, self, varargin{:});
     end
     function varargout = getRefTorque(self,varargin)
     %Usage: retval = getRefTorque (j, t)
     %
     %j is of type int. t is of type double *. j is of type int. t is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1626, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1612, self, varargin{:});
     end
     function varargout = setRefTorque(self,varargin)
     %Usage: retval = setRefTorque (j, t)
     %
     %j is of type int. t is of type double. j is of type int. t is of type double. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1627, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1613, self, varargin{:});
     end
     function varargout = setRefTorques(self,varargin)
     %Usage: retval = setRefTorques (n_joint, joints, t)
     %
     %n_joint is of type int const. joints is of type int const *. t is of type double const *. n_joint is of type int const. joints is of type int const *. t is of type double const *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1628, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1614, self, varargin{:});
     end
     function varargout = getMotorTorqueParams(self,varargin)
     %Usage: retval = getMotorTorqueParams (j, params)
     %
     %j is of type int. params is of type MotorTorqueParameters. j is of type int. params is of type MotorTorqueParameters. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1629, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1615, self, varargin{:});
     end
     function varargout = setMotorTorqueParams(self,varargin)
     %Usage: retval = setMotorTorqueParams (j, params)
     %
     %j is of type int. params is of type MotorTorqueParameters. j is of type int. params is of type MotorTorqueParameters. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1630, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1616, self, varargin{:});
     end
     function varargout = getTorque(self,varargin)
     %Usage: retval = getTorque (j, t)
     %
     %j is of type int. t is of type double *. j is of type int. t is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1631, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1617, self, varargin{:});
     end
     function varargout = getTorques(self,varargin)
     %Usage: retval = getTorques (t)
     %
     %t is of type double *. t is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1632, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1618, self, varargin{:});
     end
     function varargout = getTorqueRange(self,varargin)
     %Usage: retval = getTorqueRange (j, min, max)
     %
     %j is of type int. min is of type double *. max is of type double *. j is of type int. min is of type double *. max is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1633, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1619, self, varargin{:});
     end
     function varargout = getTorqueRanges(self,varargin)
     %Usage: retval = getTorqueRanges (min, max)
     %
     %min is of type double *. max is of type double *. min is of type double *. max is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1634, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1620, self, varargin{:});
     end
     function self = ITorqueControl(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/ITorqueControlRaw.m
+++ b/matlab/autogenerated/+yarp/ITorqueControlRaw.m
@@ -7,7 +7,7 @@ classdef ITorqueControlRaw < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1635, self);
+        yarpMEX(1621, self);
         self.SwigClear();
       end
     end
@@ -15,67 +15,67 @@ classdef ITorqueControlRaw < SwigRef
     %Usage: retval = getAxes (ax)
     %
     %ax is of type int *. ax is of type int *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1636, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1622, self, varargin{:});
     end
     function varargout = getTorqueRaw(self,varargin)
     %Usage: retval = getTorqueRaw (j, t)
     %
     %j is of type int. t is of type double *. j is of type int. t is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1637, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1623, self, varargin{:});
     end
     function varargout = getTorquesRaw(self,varargin)
     %Usage: retval = getTorquesRaw (t)
     %
     %t is of type double *. t is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1638, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1624, self, varargin{:});
     end
     function varargout = getTorqueRangeRaw(self,varargin)
     %Usage: retval = getTorqueRangeRaw (j, min, max)
     %
     %j is of type int. min is of type double *. max is of type double *. j is of type int. min is of type double *. max is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1639, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1625, self, varargin{:});
     end
     function varargout = getTorqueRangesRaw(self,varargin)
     %Usage: retval = getTorqueRangesRaw (min, max)
     %
     %min is of type double *. max is of type double *. min is of type double *. max is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1640, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1626, self, varargin{:});
     end
     function varargout = setRefTorqueRaw(self,varargin)
     %Usage: retval = setRefTorqueRaw (j, t)
     %
     %j is of type int. t is of type double. j is of type int. t is of type double. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1641, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1627, self, varargin{:});
     end
     function varargout = setRefTorquesRaw(self,varargin)
     %Usage: retval = setRefTorquesRaw (n_joint, joints, t)
     %
     %n_joint is of type int const. joints is of type int const *. t is of type double const *. n_joint is of type int const. joints is of type int const *. t is of type double const *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1642, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1628, self, varargin{:});
     end
     function varargout = getRefTorquesRaw(self,varargin)
     %Usage: retval = getRefTorquesRaw (t)
     %
     %t is of type double *. t is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1643, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1629, self, varargin{:});
     end
     function varargout = getRefTorqueRaw(self,varargin)
     %Usage: retval = getRefTorqueRaw (j, t)
     %
     %j is of type int. t is of type double *. j is of type int. t is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1644, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1630, self, varargin{:});
     end
     function varargout = getMotorTorqueParamsRaw(self,varargin)
     %Usage: retval = getMotorTorqueParamsRaw (j, params)
     %
     %j is of type int. params is of type MotorTorqueParameters. j is of type int. params is of type MotorTorqueParameters. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1645, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1631, self, varargin{:});
     end
     function varargout = setMotorTorqueParamsRaw(self,varargin)
     %Usage: retval = setMotorTorqueParamsRaw (j, params)
     %
     %j is of type int. params is of type MotorTorqueParameters. j is of type int. params is of type MotorTorqueParameters. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1646, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1632, self, varargin{:});
     end
     function self = ITorqueControlRaw(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/IVector.m
+++ b/matlab/autogenerated/+yarp/IVector.m
@@ -9,89 +9,89 @@ classdef IVector < SwigRef
     %Usage: retval = pop ()
     %
     %retval is of type std::vector< int >::value_type. 
-      [varargout{1:nargout}] = yarpMEX(1862, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1848, self, varargin{:});
     end
     function varargout = brace(self,varargin)
     %Usage: retval = brace (i)
     %
     %i is of type std::vector< int >::difference_type. i is of type std::vector< int >::difference_type. retval is of type std::vector< int >::value_type. 
-      [varargout{1:nargout}] = yarpMEX(1863, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1849, self, varargin{:});
     end
     function varargout = setbrace(self,varargin)
     %Usage: setbrace (x, i)
     %
     %x is of type std::vector< int >::value_type. i is of type std::vector< int >::difference_type. 
-      [varargout{1:nargout}] = yarpMEX(1864, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1850, self, varargin{:});
     end
     function varargout = append(self,varargin)
     %Usage: append (x)
     %
     %x is of type std::vector< int >::value_type. 
-      [varargout{1:nargout}] = yarpMEX(1865, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1851, self, varargin{:});
     end
     function varargout = empty(self,varargin)
     %Usage: retval = empty ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1866, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1852, self, varargin{:});
     end
     function varargout = size(self,varargin)
     %Usage: retval = size ()
     %
     %retval is of type std::vector< int >::size_type. 
-      [varargout{1:nargout}] = yarpMEX(1867, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1853, self, varargin{:});
     end
     function varargout = swap(self,varargin)
     %Usage: swap (v)
     %
     %v is of type IVector. 
-      [varargout{1:nargout}] = yarpMEX(1868, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1854, self, varargin{:});
     end
     function varargout = begin(self,varargin)
     %Usage: retval = begin ()
     %
     %retval is of type std::vector< int >::iterator. 
-      [varargout{1:nargout}] = yarpMEX(1869, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1855, self, varargin{:});
     end
     function varargout = end(self,varargin)
     %Usage: retval = end ()
     %
     %retval is of type std::vector< int >::iterator. 
-      [varargout{1:nargout}] = yarpMEX(1870, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1856, self, varargin{:});
     end
     function varargout = rbegin(self,varargin)
     %Usage: retval = rbegin ()
     %
     %retval is of type std::vector< int >::reverse_iterator. 
-      [varargout{1:nargout}] = yarpMEX(1871, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1857, self, varargin{:});
     end
     function varargout = rend(self,varargin)
     %Usage: retval = rend ()
     %
     %retval is of type std::vector< int >::reverse_iterator. 
-      [varargout{1:nargout}] = yarpMEX(1872, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1858, self, varargin{:});
     end
     function varargout = clear(self,varargin)
     %Usage: clear ()
     %
-      [varargout{1:nargout}] = yarpMEX(1873, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1859, self, varargin{:});
     end
     function varargout = get_allocator(self,varargin)
     %Usage: retval = get_allocator ()
     %
     %retval is of type std::vector< int >::allocator_type. 
-      [varargout{1:nargout}] = yarpMEX(1874, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1860, self, varargin{:});
     end
     function varargout = pop_back(self,varargin)
     %Usage: pop_back ()
     %
-      [varargout{1:nargout}] = yarpMEX(1875, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1861, self, varargin{:});
     end
     function varargout = erase(self,varargin)
     %Usage: retval = erase (first, last)
     %
     %first is of type std::vector< int >::iterator. last is of type std::vector< int >::iterator. first is of type std::vector< int >::iterator. last is of type std::vector< int >::iterator. retval is of type std::vector< int >::iterator. 
-      [varargout{1:nargout}] = yarpMEX(1876, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1862, self, varargin{:});
     end
     function self = IVector(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -99,7 +99,7 @@ classdef IVector < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(1877, varargin{:});
+        tmp = yarpMEX(1863, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
@@ -108,70 +108,70 @@ classdef IVector < SwigRef
     %Usage: push_back (x)
     %
     %x is of type std::vector< int >::value_type const &. 
-      [varargout{1:nargout}] = yarpMEX(1878, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1864, self, varargin{:});
     end
     function varargout = front(self,varargin)
     %Usage: retval = front ()
     %
     %retval is of type std::vector< int >::value_type const &. 
-      [varargout{1:nargout}] = yarpMEX(1879, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1865, self, varargin{:});
     end
     function varargout = back(self,varargin)
     %Usage: retval = back ()
     %
     %retval is of type std::vector< int >::value_type const &. 
-      [varargout{1:nargout}] = yarpMEX(1880, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1866, self, varargin{:});
     end
     function varargout = assign(self,varargin)
     %Usage: assign (n, x)
     %
     %n is of type std::vector< int >::size_type. x is of type std::vector< int >::value_type const &. 
-      [varargout{1:nargout}] = yarpMEX(1881, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1867, self, varargin{:});
     end
     function varargout = resize(self,varargin)
     %Usage: resize (new_size, x)
     %
     %new_size is of type std::vector< int >::size_type. x is of type std::vector< int >::value_type const &. 
-      [varargout{1:nargout}] = yarpMEX(1882, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1868, self, varargin{:});
     end
     function varargout = insert(self,varargin)
     %Usage: insert (pos, n, x)
     %
     %pos is of type std::vector< int >::iterator. n is of type std::vector< int >::size_type. x is of type std::vector< int >::value_type const &. 
-      [varargout{1:nargout}] = yarpMEX(1883, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1869, self, varargin{:});
     end
     function varargout = reserve(self,varargin)
     %Usage: reserve (n)
     %
     %n is of type std::vector< int >::size_type. 
-      [varargout{1:nargout}] = yarpMEX(1884, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1870, self, varargin{:});
     end
     function varargout = capacity(self,varargin)
     %Usage: retval = capacity ()
     %
     %retval is of type std::vector< int >::size_type. 
-      [varargout{1:nargout}] = yarpMEX(1885, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1871, self, varargin{:});
     end
     function varargout = toMatlab(self,varargin)
     %Usage: retval = toMatlab ()
     %
     %retval is of type mxArray *. 
-      [varargout{1:nargout}] = yarpMEX(1886, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1872, self, varargin{:});
     end
     function varargout = fromMatlab(self,varargin)
     %Usage: fromMatlab (in)
     %
     %in is of type mxArray *. 
-      [varargout{1:nargout}] = yarpMEX(1887, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1873, self, varargin{:});
     end
     function varargout = zero(self,varargin)
     %Usage: zero ()
     %
-      [varargout{1:nargout}] = yarpMEX(1888, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1874, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1889, self);
+        yarpMEX(1875, self);
         self.SwigClear();
       end
     end

--- a/matlab/autogenerated/+yarp/IVelocityControl.m
+++ b/matlab/autogenerated/+yarp/IVelocityControl.m
@@ -7,7 +7,7 @@ classdef IVelocityControl < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1671, self);
+        yarpMEX(1657, self);
         self.SwigClear();
       end
     end
@@ -15,55 +15,55 @@ classdef IVelocityControl < SwigRef
     %Usage: retval = setRefAcceleration (j, acc)
     %
     %j is of type int. acc is of type double. j is of type int. acc is of type double. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1672, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1658, self, varargin{:});
     end
     function varargout = getRefVelocity(self,varargin)
     %Usage: retval = getRefVelocity (joint, vel)
     %
     %joint is of type int const. vel is of type double *. joint is of type int const. vel is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1673, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1659, self, varargin{:});
     end
     function varargout = getRefVelocities(self,varargin)
     %Usage: retval = getRefVelocities (n_joint, joints, vels)
     %
     %n_joint is of type int const. joints is of type int const *. vels is of type double *. n_joint is of type int const. joints is of type int const *. vels is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1674, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1660, self, varargin{:});
     end
     function varargout = stop(self,varargin)
     %Usage: retval = stop (n_joint, joints)
     %
     %n_joint is of type int const. joints is of type int const *. n_joint is of type int const. joints is of type int const *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1675, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1661, self, varargin{:});
     end
     function varargout = getAxes(self,varargin)
     %Usage: retval = getAxes ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(1676, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1662, self, varargin{:});
     end
     function varargout = velocityMove(self,varargin)
     %Usage: retval = velocityMove (data)
     %
     %data is of type DVector. data is of type DVector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1677, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1663, self, varargin{:});
     end
     function varargout = setRefAccelerations(self,varargin)
     %Usage: retval = setRefAccelerations (data)
     %
     %data is of type DVector. data is of type DVector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1678, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1664, self, varargin{:});
     end
     function varargout = getRefAcceleration(self,varargin)
     %Usage: retval = getRefAcceleration (j, data)
     %
     %j is of type int. data is of type DVector. j is of type int. data is of type DVector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1679, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1665, self, varargin{:});
     end
     function varargout = getRefAccelerations(self,varargin)
     %Usage: retval = getRefAccelerations (data)
     %
     %data is of type DVector. data is of type DVector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1680, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1666, self, varargin{:});
     end
     function self = IVelocityControl(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/IVelocityControlRaw.m
+++ b/matlab/autogenerated/+yarp/IVelocityControlRaw.m
@@ -7,7 +7,7 @@ classdef IVelocityControlRaw < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1661, self);
+        yarpMEX(1647, self);
         self.SwigClear();
       end
     end
@@ -15,55 +15,55 @@ classdef IVelocityControlRaw < SwigRef
     %Usage: retval = getAxes (axis)
     %
     %axis is of type int *. axis is of type int *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1662, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1648, self, varargin{:});
     end
     function varargout = setRefAccelerationRaw(self,varargin)
     %Usage: retval = setRefAccelerationRaw (j, acc)
     %
     %j is of type int. acc is of type double. j is of type int. acc is of type double. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1663, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1649, self, varargin{:});
     end
     function varargout = getRefAccelerationRaw(self,varargin)
     %Usage: retval = getRefAccelerationRaw (j, acc)
     %
     %j is of type int. acc is of type double *. j is of type int. acc is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1664, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1650, self, varargin{:});
     end
     function varargout = velocityMoveRaw(self,varargin)
     %Usage: retval = velocityMoveRaw (n_joint, joints, spds)
     %
     %n_joint is of type int const. joints is of type int const *. spds is of type double const *. n_joint is of type int const. joints is of type int const *. spds is of type double const *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1665, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1651, self, varargin{:});
     end
     function varargout = getRefVelocityRaw(self,varargin)
     %Usage: retval = getRefVelocityRaw (joint, vel)
     %
     %joint is of type int const. vel is of type double *. joint is of type int const. vel is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1666, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1652, self, varargin{:});
     end
     function varargout = getRefVelocitiesRaw(self,varargin)
     %Usage: retval = getRefVelocitiesRaw (n_joint, joints, vels)
     %
     %n_joint is of type int const. joints is of type int const *. vels is of type double *. n_joint is of type int const. joints is of type int const *. vels is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1667, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1653, self, varargin{:});
     end
     function varargout = setRefAccelerationsRaw(self,varargin)
     %Usage: retval = setRefAccelerationsRaw (n_joint, joints, accs)
     %
     %n_joint is of type int const. joints is of type int const *. accs is of type double const *. n_joint is of type int const. joints is of type int const *. accs is of type double const *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1668, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1654, self, varargin{:});
     end
     function varargout = getRefAccelerationsRaw(self,varargin)
     %Usage: retval = getRefAccelerationsRaw (n_joint, joints, accs)
     %
     %n_joint is of type int const. joints is of type int const *. accs is of type double *. n_joint is of type int const. joints is of type int const *. accs is of type double *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1669, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1655, self, varargin{:});
     end
     function varargout = stopRaw(self,varargin)
     %Usage: retval = stopRaw (n_joint, joints)
     %
     %n_joint is of type int const. joints is of type int const *. n_joint is of type int const. joints is of type int const *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1670, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1656, self, varargin{:});
     end
     function self = IVelocityControlRaw(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/Image.m
+++ b/matlab/autogenerated/+yarp/Image.m
@@ -9,14 +9,14 @@ classdef Image < yarp.Portable
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(858, varargin{:});
+        tmp = yarpMEX(844, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(859, self);
+        yarpMEX(845, self);
         self.SwigClear();
       end
     end
@@ -24,144 +24,144 @@ classdef Image < yarp.Portable
     %Usage: retval = copy (alt, w, h)
     %
     %alt is of type Image. w is of type size_t. h is of type size_t. alt is of type Image. w is of type size_t. h is of type size_t. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(860, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(846, self, varargin{:});
     end
     function varargout = width(self,varargin)
     %Usage: retval = width ()
     %
     %retval is of type size_t. 
-      [varargout{1:nargout}] = yarpMEX(861, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(847, self, varargin{:});
     end
     function varargout = height(self,varargin)
     %Usage: retval = height ()
     %
     %retval is of type size_t. 
-      [varargout{1:nargout}] = yarpMEX(862, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(848, self, varargin{:});
     end
     function varargout = getPixelSize(self,varargin)
     %Usage: retval = getPixelSize ()
     %
     %retval is of type size_t. 
-      [varargout{1:nargout}] = yarpMEX(863, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(849, self, varargin{:});
     end
     function varargout = getPixelCode(self,varargin)
     %Usage: retval = getPixelCode ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(864, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(850, self, varargin{:});
     end
     function varargout = getRowSize(self,varargin)
     %Usage: retval = getRowSize ()
     %
     %retval is of type size_t. 
-      [varargout{1:nargout}] = yarpMEX(865, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(851, self, varargin{:});
     end
     function varargout = getQuantum(self,varargin)
     %Usage: retval = getQuantum ()
     %
     %retval is of type size_t. 
-      [varargout{1:nargout}] = yarpMEX(866, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(852, self, varargin{:});
     end
     function varargout = getPadding(self,varargin)
     %Usage: retval = getPadding ()
     %
     %retval is of type size_t. 
-      [varargout{1:nargout}] = yarpMEX(867, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(853, self, varargin{:});
     end
     function varargout = getRow(self,varargin)
     %Usage: retval = getRow (r)
     %
     %r is of type size_t. r is of type size_t. retval is of type unsigned char const *. 
-      [varargout{1:nargout}] = yarpMEX(868, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(854, self, varargin{:});
     end
     function varargout = getPixelAddress(self,varargin)
     %Usage: retval = getPixelAddress (x, y)
     %
     %x is of type size_t. y is of type size_t. x is of type size_t. y is of type size_t. retval is of type unsigned char *. 
-      [varargout{1:nargout}] = yarpMEX(869, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(855, self, varargin{:});
     end
     function varargout = isPixel(self,varargin)
     %Usage: retval = isPixel (x, y)
     %
     %x is of type size_t. y is of type size_t. x is of type size_t. y is of type size_t. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(870, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(856, self, varargin{:});
     end
     function varargout = zero(self,varargin)
     %Usage: zero ()
     %
-      [varargout{1:nargout}] = yarpMEX(871, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(857, self, varargin{:});
     end
     function varargout = resize(self,varargin)
     %Usage: resize (alt)
     %
     %alt is of type Image. 
-      [varargout{1:nargout}] = yarpMEX(872, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(858, self, varargin{:});
     end
     function varargout = setExternal(self,varargin)
     %Usage: setExternal (data, imgWidth, imgHeight)
     %
     %data is of type void const *. imgWidth is of type size_t. imgHeight is of type size_t. 
-      [varargout{1:nargout}] = yarpMEX(873, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(859, self, varargin{:});
     end
     function varargout = getRawImage(self,varargin)
     %Usage: retval = getRawImage ()
     %
     %retval is of type unsigned char *. 
-      [varargout{1:nargout}] = yarpMEX(874, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(860, self, varargin{:});
     end
     function varargout = getRawImageSize(self,varargin)
     %Usage: retval = getRawImageSize ()
     %
     %retval is of type size_t. 
-      [varargout{1:nargout}] = yarpMEX(875, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(861, self, varargin{:});
     end
     function varargout = getIplImage(self,varargin)
     %Usage: retval = getIplImage ()
     %
     %retval is of type void *. 
-      [varargout{1:nargout}] = yarpMEX(876, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(862, self, varargin{:});
     end
     function varargout = wrapIplImage(self,varargin)
     %Usage: wrapIplImage (iplImage)
     %
     %iplImage is of type void *. 
-      [varargout{1:nargout}] = yarpMEX(877, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(863, self, varargin{:});
     end
     function varargout = read(self,varargin)
     %Usage: retval = read (connection)
     %
     %connection is of type ConnectionReader. connection is of type ConnectionReader. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(878, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(864, self, varargin{:});
     end
     function varargout = write(self,varargin)
     %Usage: retval = write (connection)
     %
     %connection is of type ConnectionWriter. connection is of type ConnectionWriter. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(879, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(865, self, varargin{:});
     end
     function varargout = setQuantum(self,varargin)
     %Usage: setQuantum (imgQuantum)
     %
     %imgQuantum is of type size_t. 
-      [varargout{1:nargout}] = yarpMEX(880, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(866, self, varargin{:});
     end
     function varargout = topIsLowIndex(self,varargin)
     %Usage: retval = topIsLowIndex ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(881, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(867, self, varargin{:});
     end
     function varargout = setTopIsLowIndex(self,varargin)
     %Usage: setTopIsLowIndex (flag)
     %
     %flag is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(882, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(868, self, varargin{:});
     end
     function varargout = getRowArray(self,varargin)
     %Usage: retval = getRowArray ()
     %
     %retval is of type char **. 
-      [varargout{1:nargout}] = yarpMEX(883, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(869, self, varargin{:});
     end
   end
   methods(Static)

--- a/matlab/autogenerated/+yarp/Image.m
+++ b/matlab/autogenerated/+yarp/Image.m
@@ -1,11 +1,9 @@
-classdef Image < SwigRef
+classdef Image < yarp.Portable
     %Usage: Image ()
     %
   methods
-    function this = swig_this(self)
-      this = yarpMEX(3, self);
-    end
     function self = Image(varargin)
+      self@yarp.Portable(SwigRef.Null);
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;

--- a/matlab/autogenerated/+yarp/ImageFloat.m
+++ b/matlab/autogenerated/+yarp/ImageFloat.m
@@ -9,7 +9,7 @@ classdef ImageFloat < yarp.Image
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(2407, varargin{:});
+        tmp = yarpMEX(2393, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
@@ -18,47 +18,47 @@ classdef ImageFloat < yarp.Image
     %Usage: retval = getPixelSize ()
     %
     %retval is of type size_t. 
-      [varargout{1:nargout}] = yarpMEX(2408, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2394, self, varargin{:});
     end
     function varargout = getPixelCode(self,varargin)
     %Usage: retval = getPixelCode ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(2409, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2395, self, varargin{:});
     end
     function varargout = pixel(self,varargin)
     %Usage: retval = pixel (x, y)
     %
     %x is of type size_t. y is of type size_t. x is of type size_t. y is of type size_t. retval is of type float &. 
-      [varargout{1:nargout}] = yarpMEX(2410, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2396, self, varargin{:});
     end
     function varargout = access(self,varargin)
     %Usage: retval = access (x, y)
     %
     %x is of type size_t. y is of type size_t. x is of type size_t. y is of type size_t. retval is of type float &. 
-      [varargout{1:nargout}] = yarpMEX(2411, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2397, self, varargin{:});
     end
     function varargout = safePixel(self,varargin)
     %Usage: retval = safePixel (x, y)
     %
     %x is of type size_t. y is of type size_t. x is of type size_t. y is of type size_t. retval is of type float const &. 
-      [varargout{1:nargout}] = yarpMEX(2412, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2398, self, varargin{:});
     end
     function varargout = getPixel(self,varargin)
     %Usage: retval = getPixel (x, y)
     %
     %x is of type int. y is of type int. x is of type int. y is of type int. retval is of type float. 
-      [varargout{1:nargout}] = yarpMEX(2413, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2399, self, varargin{:});
     end
     function varargout = setPixel(self,varargin)
     %Usage: setPixel (x, y, v)
     %
     %x is of type int. y is of type int. v is of type float. 
-      [varargout{1:nargout}] = yarpMEX(2414, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2400, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(2415, self);
+        yarpMEX(2401, self);
         self.SwigClear();
       end
     end

--- a/matlab/autogenerated/+yarp/ImageFloat.m
+++ b/matlab/autogenerated/+yarp/ImageFloat.m
@@ -1,11 +1,9 @@
-classdef ImageFloat < SwigRef
+classdef ImageFloat < yarp.Image
     %Usage: ImageFloat ()
     %
   methods
-    function this = swig_this(self)
-      this = yarpMEX(3, self);
-    end
     function self = ImageFloat(varargin)
+      self@yarp.Image(SwigRef.Null);
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;

--- a/matlab/autogenerated/+yarp/ImageInt.m
+++ b/matlab/autogenerated/+yarp/ImageInt.m
@@ -9,7 +9,7 @@ classdef ImageInt < yarp.Image
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(2203, varargin{:});
+        tmp = yarpMEX(2189, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
@@ -18,47 +18,47 @@ classdef ImageInt < yarp.Image
     %Usage: retval = getPixelSize ()
     %
     %retval is of type size_t. 
-      [varargout{1:nargout}] = yarpMEX(2204, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2190, self, varargin{:});
     end
     function varargout = getPixelCode(self,varargin)
     %Usage: retval = getPixelCode ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(2205, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2191, self, varargin{:});
     end
     function varargout = pixel(self,varargin)
     %Usage: retval = pixel (x, y)
     %
     %x is of type size_t. y is of type size_t. x is of type size_t. y is of type size_t. retval is of type int &. 
-      [varargout{1:nargout}] = yarpMEX(2206, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2192, self, varargin{:});
     end
     function varargout = access(self,varargin)
     %Usage: retval = access (x, y)
     %
     %x is of type size_t. y is of type size_t. x is of type size_t. y is of type size_t. retval is of type int &. 
-      [varargout{1:nargout}] = yarpMEX(2207, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2193, self, varargin{:});
     end
     function varargout = safePixel(self,varargin)
     %Usage: retval = safePixel (x, y)
     %
     %x is of type size_t. y is of type size_t. x is of type size_t. y is of type size_t. retval is of type int const &. 
-      [varargout{1:nargout}] = yarpMEX(2208, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2194, self, varargin{:});
     end
     function varargout = getPixel(self,varargin)
     %Usage: retval = getPixel (x, y)
     %
     %x is of type int. y is of type int. x is of type int. y is of type int. retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(2209, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2195, self, varargin{:});
     end
     function varargout = setPixel(self,varargin)
     %Usage: setPixel (x, y, v)
     %
     %x is of type int. y is of type int. v is of type int. 
-      [varargout{1:nargout}] = yarpMEX(2210, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2196, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(2211, self);
+        yarpMEX(2197, self);
         self.SwigClear();
       end
     end

--- a/matlab/autogenerated/+yarp/ImageInt.m
+++ b/matlab/autogenerated/+yarp/ImageInt.m
@@ -1,11 +1,9 @@
-classdef ImageInt < SwigRef
+classdef ImageInt < yarp.Image
     %Usage: ImageInt ()
     %
   methods
-    function this = swig_this(self)
-      this = yarpMEX(3, self);
-    end
     function self = ImageInt(varargin)
+      self@yarp.Image(SwigRef.Null);
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;

--- a/matlab/autogenerated/+yarp/ImageMono.m
+++ b/matlab/autogenerated/+yarp/ImageMono.m
@@ -1,11 +1,9 @@
-classdef ImageMono < SwigRef
+classdef ImageMono < yarp.Image
     %Usage: ImageMono ()
     %
   methods
-    function this = swig_this(self)
-      this = yarpMEX(3, self);
-    end
     function self = ImageMono(varargin)
+      self@yarp.Image(SwigRef.Null);
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;

--- a/matlab/autogenerated/+yarp/ImageMono.m
+++ b/matlab/autogenerated/+yarp/ImageMono.m
@@ -9,7 +9,7 @@ classdef ImageMono < yarp.Image
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(2059, varargin{:});
+        tmp = yarpMEX(2045, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
@@ -18,35 +18,35 @@ classdef ImageMono < yarp.Image
     %Usage: retval = getPixelSize ()
     %
     %retval is of type size_t. 
-      [varargout{1:nargout}] = yarpMEX(2060, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2046, self, varargin{:});
     end
     function varargout = getPixelCode(self,varargin)
     %Usage: retval = getPixelCode ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(2061, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2047, self, varargin{:});
     end
     function varargout = pixel(self,varargin)
     %Usage: retval = pixel (x, y)
     %
     %x is of type size_t. y is of type size_t. x is of type size_t. y is of type size_t. retval is of type unsigned char &. 
-      [varargout{1:nargout}] = yarpMEX(2062, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2048, self, varargin{:});
     end
     function varargout = access(self,varargin)
     %Usage: retval = access (x, y)
     %
     %x is of type size_t. y is of type size_t. x is of type size_t. y is of type size_t. retval is of type unsigned char &. 
-      [varargout{1:nargout}] = yarpMEX(2063, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2049, self, varargin{:});
     end
     function varargout = safePixel(self,varargin)
     %Usage: retval = safePixel (x, y)
     %
     %x is of type size_t. y is of type size_t. x is of type size_t. y is of type size_t. retval is of type unsigned char const &. 
-      [varargout{1:nargout}] = yarpMEX(2064, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2050, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(2065, self);
+        yarpMEX(2051, self);
         self.SwigClear();
       end
     end

--- a/matlab/autogenerated/+yarp/ImageMono16.m
+++ b/matlab/autogenerated/+yarp/ImageMono16.m
@@ -9,7 +9,7 @@ classdef ImageMono16 < yarp.Image
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(2131, varargin{:});
+        tmp = yarpMEX(2117, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
@@ -18,35 +18,35 @@ classdef ImageMono16 < yarp.Image
     %Usage: retval = getPixelSize ()
     %
     %retval is of type size_t. 
-      [varargout{1:nargout}] = yarpMEX(2132, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2118, self, varargin{:});
     end
     function varargout = getPixelCode(self,varargin)
     %Usage: retval = getPixelCode ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(2133, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2119, self, varargin{:});
     end
     function varargout = pixel(self,varargin)
     %Usage: retval = pixel (x, y)
     %
     %x is of type size_t. y is of type size_t. x is of type size_t. y is of type size_t. retval is of type yarp::os::NetUint16 &. 
-      [varargout{1:nargout}] = yarpMEX(2134, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2120, self, varargin{:});
     end
     function varargout = access(self,varargin)
     %Usage: retval = access (x, y)
     %
     %x is of type size_t. y is of type size_t. x is of type size_t. y is of type size_t. retval is of type yarp::os::NetUint16 &. 
-      [varargout{1:nargout}] = yarpMEX(2135, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2121, self, varargin{:});
     end
     function varargout = safePixel(self,varargin)
     %Usage: retval = safePixel (x, y)
     %
     %x is of type size_t. y is of type size_t. x is of type size_t. y is of type size_t. retval is of type yarp::os::NetUint16 const &. 
-      [varargout{1:nargout}] = yarpMEX(2136, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2122, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(2137, self);
+        yarpMEX(2123, self);
         self.SwigClear();
       end
     end

--- a/matlab/autogenerated/+yarp/ImageMono16.m
+++ b/matlab/autogenerated/+yarp/ImageMono16.m
@@ -1,11 +1,9 @@
-classdef ImageMono16 < SwigRef
+classdef ImageMono16 < yarp.Image
     %Usage: ImageMono16 ()
     %
   methods
-    function this = swig_this(self)
-      this = yarpMEX(3, self);
-    end
     function self = ImageMono16(varargin)
+      self@yarp.Image(SwigRef.Null);
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;

--- a/matlab/autogenerated/+yarp/ImageRgb.m
+++ b/matlab/autogenerated/+yarp/ImageRgb.m
@@ -1,11 +1,9 @@
-classdef ImageRgb < SwigRef
+classdef ImageRgb < yarp.Image
     %Usage: ImageRgb ()
     %
   methods
-    function this = swig_this(self)
-      this = yarpMEX(3, self);
-    end
     function self = ImageRgb(varargin)
+      self@yarp.Image(SwigRef.Null);
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;

--- a/matlab/autogenerated/+yarp/ImageRgb.m
+++ b/matlab/autogenerated/+yarp/ImageRgb.m
@@ -9,7 +9,7 @@ classdef ImageRgb < yarp.Image
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(1915, varargin{:});
+        tmp = yarpMEX(1901, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
@@ -18,35 +18,35 @@ classdef ImageRgb < yarp.Image
     %Usage: retval = getPixelSize ()
     %
     %retval is of type size_t. 
-      [varargout{1:nargout}] = yarpMEX(1916, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1902, self, varargin{:});
     end
     function varargout = getPixelCode(self,varargin)
     %Usage: retval = getPixelCode ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(1917, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1903, self, varargin{:});
     end
     function varargout = pixel(self,varargin)
     %Usage: retval = pixel (x, y)
     %
     %x is of type size_t. y is of type size_t. x is of type size_t. y is of type size_t. retval is of type PixelRgb. 
-      [varargout{1:nargout}] = yarpMEX(1918, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1904, self, varargin{:});
     end
     function varargout = access(self,varargin)
     %Usage: retval = access (x, y)
     %
     %x is of type size_t. y is of type size_t. x is of type size_t. y is of type size_t. retval is of type PixelRgb. 
-      [varargout{1:nargout}] = yarpMEX(1919, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1905, self, varargin{:});
     end
     function varargout = safePixel(self,varargin)
     %Usage: retval = safePixel (x, y)
     %
     %x is of type size_t. y is of type size_t. x is of type size_t. y is of type size_t. retval is of type PixelRgb. 
-      [varargout{1:nargout}] = yarpMEX(1920, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1906, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1921, self);
+        yarpMEX(1907, self);
         self.SwigClear();
       end
     end

--- a/matlab/autogenerated/+yarp/ImageRgbFloat.m
+++ b/matlab/autogenerated/+yarp/ImageRgbFloat.m
@@ -9,7 +9,7 @@ classdef ImageRgbFloat < yarp.Image
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(2481, varargin{:});
+        tmp = yarpMEX(2467, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
@@ -18,35 +18,35 @@ classdef ImageRgbFloat < yarp.Image
     %Usage: retval = getPixelSize ()
     %
     %retval is of type size_t. 
-      [varargout{1:nargout}] = yarpMEX(2482, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2468, self, varargin{:});
     end
     function varargout = getPixelCode(self,varargin)
     %Usage: retval = getPixelCode ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(2483, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2469, self, varargin{:});
     end
     function varargout = pixel(self,varargin)
     %Usage: retval = pixel (x, y)
     %
     %x is of type size_t. y is of type size_t. x is of type size_t. y is of type size_t. retval is of type PixelRgbFloat. 
-      [varargout{1:nargout}] = yarpMEX(2484, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2470, self, varargin{:});
     end
     function varargout = access(self,varargin)
     %Usage: retval = access (x, y)
     %
     %x is of type size_t. y is of type size_t. x is of type size_t. y is of type size_t. retval is of type PixelRgbFloat. 
-      [varargout{1:nargout}] = yarpMEX(2485, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2471, self, varargin{:});
     end
     function varargout = safePixel(self,varargin)
     %Usage: retval = safePixel (x, y)
     %
     %x is of type size_t. y is of type size_t. x is of type size_t. y is of type size_t. retval is of type PixelRgbFloat. 
-      [varargout{1:nargout}] = yarpMEX(2486, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2472, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(2487, self);
+        yarpMEX(2473, self);
         self.SwigClear();
       end
     end

--- a/matlab/autogenerated/+yarp/ImageRgbFloat.m
+++ b/matlab/autogenerated/+yarp/ImageRgbFloat.m
@@ -1,11 +1,9 @@
-classdef ImageRgbFloat < SwigRef
+classdef ImageRgbFloat < yarp.Image
     %Usage: ImageRgbFloat ()
     %
   methods
-    function this = swig_this(self)
-      this = yarpMEX(3, self);
-    end
     function self = ImageRgbFloat(varargin)
+      self@yarp.Image(SwigRef.Null);
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;

--- a/matlab/autogenerated/+yarp/ImageRgba.m
+++ b/matlab/autogenerated/+yarp/ImageRgba.m
@@ -1,11 +1,9 @@
-classdef ImageRgba < SwigRef
+classdef ImageRgba < yarp.Image
     %Usage: ImageRgba ()
     %
   methods
-    function this = swig_this(self)
-      this = yarpMEX(3, self);
-    end
     function self = ImageRgba(varargin)
+      self@yarp.Image(SwigRef.Null);
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;

--- a/matlab/autogenerated/+yarp/ImageRgba.m
+++ b/matlab/autogenerated/+yarp/ImageRgba.m
@@ -9,7 +9,7 @@ classdef ImageRgba < yarp.Image
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(1987, varargin{:});
+        tmp = yarpMEX(1973, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
@@ -18,35 +18,35 @@ classdef ImageRgba < yarp.Image
     %Usage: retval = getPixelSize ()
     %
     %retval is of type size_t. 
-      [varargout{1:nargout}] = yarpMEX(1988, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1974, self, varargin{:});
     end
     function varargout = getPixelCode(self,varargin)
     %Usage: retval = getPixelCode ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(1989, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1975, self, varargin{:});
     end
     function varargout = pixel(self,varargin)
     %Usage: retval = pixel (x, y)
     %
     %x is of type size_t. y is of type size_t. x is of type size_t. y is of type size_t. retval is of type PixelRgba. 
-      [varargout{1:nargout}] = yarpMEX(1990, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1976, self, varargin{:});
     end
     function varargout = access(self,varargin)
     %Usage: retval = access (x, y)
     %
     %x is of type size_t. y is of type size_t. x is of type size_t. y is of type size_t. retval is of type PixelRgba. 
-      [varargout{1:nargout}] = yarpMEX(1991, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1977, self, varargin{:});
     end
     function varargout = safePixel(self,varargin)
     %Usage: retval = safePixel (x, y)
     %
     %x is of type size_t. y is of type size_t. x is of type size_t. y is of type size_t. retval is of type PixelRgba. 
-      [varargout{1:nargout}] = yarpMEX(1992, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1978, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1993, self);
+        yarpMEX(1979, self);
         self.SwigClear();
       end
     end

--- a/matlab/autogenerated/+yarp/Log.m
+++ b/matlab/autogenerated/+yarp/Log.m
@@ -11,14 +11,14 @@ classdef Log < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(715, varargin{:});
+        tmp = yarpMEX(701, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(716, self);
+        yarpMEX(702, self);
         self.SwigClear();
       end
     end
@@ -26,37 +26,37 @@ classdef Log < SwigRef
     %Usage: retval = trace ()
     %
     %retval is of type LogStream. 
-      [varargout{1:nargout}] = yarpMEX(717, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(703, self, varargin{:});
     end
     function varargout = debug(self,varargin)
     %Usage: retval = debug ()
     %
     %retval is of type LogStream. 
-      [varargout{1:nargout}] = yarpMEX(718, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(704, self, varargin{:});
     end
     function varargout = info(self,varargin)
     %Usage: retval = info ()
     %
     %retval is of type LogStream. 
-      [varargout{1:nargout}] = yarpMEX(719, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(705, self, varargin{:});
     end
     function varargout = warning(self,varargin)
     %Usage: retval = warning ()
     %
     %retval is of type LogStream. 
-      [varargout{1:nargout}] = yarpMEX(720, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(706, self, varargin{:});
     end
     function varargout = error(self,varargin)
     %Usage: retval = error ()
     %
     %retval is of type LogStream. 
-      [varargout{1:nargout}] = yarpMEX(721, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(707, self, varargin{:});
     end
     function varargout = fatal(self,varargin)
     %Usage: retval = fatal ()
     %
     %retval is of type LogStream. 
-      [varargout{1:nargout}] = yarpMEX(722, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(708, self, varargin{:});
     end
   end
   methods(Static)
@@ -106,7 +106,7 @@ classdef Log < SwigRef
     %Usage: setLogCallback (arg1)
     %
     %arg1 is of type yarp::os::Log::LogCallback. 
-     [varargout{1:nargout}] = yarpMEX(723, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(709, varargin{:});
     end
   end
 end

--- a/matlab/autogenerated/+yarp/LogStream.m
+++ b/matlab/autogenerated/+yarp/LogStream.m
@@ -11,14 +11,14 @@ classdef LogStream < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(725, varargin{:});
+        tmp = yarpMEX(711, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(726, self);
+        yarpMEX(712, self);
         self.SwigClear();
       end
     end

--- a/matlab/autogenerated/+yarp/Matrix.m
+++ b/matlab/autogenerated/+yarp/Matrix.m
@@ -9,14 +9,14 @@ classdef Matrix < yarp.Portable
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(989, varargin{:});
+        tmp = yarpMEX(975, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(990, self);
+        yarpMEX(976, self);
         self.SwigClear();
       end
     end
@@ -24,174 +24,174 @@ classdef Matrix < yarp.Portable
     %Usage: retval = rows ()
     %
     %retval is of type size_t. 
-      [varargout{1:nargout}] = yarpMEX(991, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(977, self, varargin{:});
     end
     function varargout = cols(self,varargin)
     %Usage: retval = cols ()
     %
     %retval is of type size_t. 
-      [varargout{1:nargout}] = yarpMEX(992, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(978, self, varargin{:});
     end
     function varargout = resize(self,varargin)
     %Usage: resize (r, c)
     %
     %r is of type size_t. c is of type size_t. 
-      [varargout{1:nargout}] = yarpMEX(993, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(979, self, varargin{:});
     end
     function varargout = brace(self,varargin)
     %Usage: retval = brace (r)
     %
     %r is of type size_t. r is of type size_t. retval is of type double const *. 
-      [varargout{1:nargout}] = yarpMEX(994, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(980, self, varargin{:});
     end
     function varargout = access(self,varargin)
     %Usage: retval = access (r, c)
     %
     %r is of type size_t. c is of type size_t. r is of type size_t. c is of type size_t. retval is of type double &. 
-      [varargout{1:nargout}] = yarpMEX(995, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(981, self, varargin{:});
     end
     function varargout = zero(self,varargin)
     %Usage: zero ()
     %
-      [varargout{1:nargout}] = yarpMEX(996, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(982, self, varargin{:});
     end
     function varargout = setRow(self,varargin)
     %Usage: retval = setRow (row, r)
     %
     %row is of type size_t. r is of type Vector const &. row is of type size_t. r is of type Vector const &. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(997, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(983, self, varargin{:});
     end
     function varargout = setCol(self,varargin)
     %Usage: retval = setCol (col, c)
     %
     %col is of type size_t. c is of type Vector const &. col is of type size_t. c is of type Vector const &. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(998, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(984, self, varargin{:});
     end
     function varargout = transposed(self,varargin)
     %Usage: retval = transposed ()
     %
     %retval is of type Matrix. 
-      [varargout{1:nargout}] = yarpMEX(999, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(985, self, varargin{:});
     end
     function varargout = eye(self,varargin)
     %Usage: retval = eye ()
     %
     %retval is of type Matrix. 
-      [varargout{1:nargout}] = yarpMEX(1000, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(986, self, varargin{:});
     end
     function varargout = diagonal(self,varargin)
     %Usage: retval = diagonal (d)
     %
     %d is of type Vector const &. d is of type Vector const &. retval is of type Matrix. 
-      [varargout{1:nargout}] = yarpMEX(1001, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(987, self, varargin{:});
     end
     function varargout = submatrix(self,varargin)
     %Usage: retval = submatrix (r1, r2, c1, c2)
     %
     %r1 is of type size_t. r2 is of type size_t. c1 is of type size_t. c2 is of type size_t. r1 is of type size_t. r2 is of type size_t. c1 is of type size_t. c2 is of type size_t. retval is of type Matrix. 
-      [varargout{1:nargout}] = yarpMEX(1002, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(988, self, varargin{:});
     end
     function varargout = setSubmatrix(self,varargin)
     %Usage: retval = setSubmatrix (m, r, c)
     %
     %m is of type Matrix. r is of type size_t. c is of type size_t. m is of type Matrix. r is of type size_t. c is of type size_t. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1003, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(989, self, varargin{:});
     end
     function varargout = setSubrow(self,varargin)
     %Usage: retval = setSubrow (v, r, c)
     %
     %v is of type Vector const &. r is of type size_t. c is of type size_t. v is of type Vector const &. r is of type size_t. c is of type size_t. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1004, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(990, self, varargin{:});
     end
     function varargout = setSubcol(self,varargin)
     %Usage: retval = setSubcol (v, r, c)
     %
     %v is of type Vector const &. r is of type size_t. c is of type size_t. v is of type Vector const &. r is of type size_t. c is of type size_t. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1005, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(991, self, varargin{:});
     end
     function varargout = getRow(self,varargin)
     %Usage: retval = getRow (r)
     %
     %r is of type size_t. r is of type size_t. retval is of type Vector. 
-      [varargout{1:nargout}] = yarpMEX(1006, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(992, self, varargin{:});
     end
     function varargout = getCol(self,varargin)
     %Usage: retval = getCol (c)
     %
     %c is of type size_t. c is of type size_t. retval is of type Vector. 
-      [varargout{1:nargout}] = yarpMEX(1007, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(993, self, varargin{:});
     end
     function varargout = removeCols(self,varargin)
     %Usage: retval = removeCols (first_col, how_many)
     %
     %first_col is of type size_t. how_many is of type size_t. first_col is of type size_t. how_many is of type size_t. retval is of type Matrix. 
-      [varargout{1:nargout}] = yarpMEX(1008, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(994, self, varargin{:});
     end
     function varargout = removeRows(self,varargin)
     %Usage: retval = removeRows (first_row, how_many)
     %
     %first_row is of type size_t. how_many is of type size_t. first_row is of type size_t. how_many is of type size_t. retval is of type Matrix. 
-      [varargout{1:nargout}] = yarpMEX(1009, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(995, self, varargin{:});
     end
     function varargout = subrow(self,varargin)
     %Usage: retval = subrow (r, c, size)
     %
     %r is of type size_t. c is of type size_t. size is of type size_t. r is of type size_t. c is of type size_t. size is of type size_t. retval is of type Vector. 
-      [varargout{1:nargout}] = yarpMEX(1010, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(996, self, varargin{:});
     end
     function varargout = subcol(self,varargin)
     %Usage: retval = subcol (r, c, size)
     %
     %r is of type size_t. c is of type size_t. size is of type size_t. r is of type size_t. c is of type size_t. size is of type size_t. retval is of type Vector. 
-      [varargout{1:nargout}] = yarpMEX(1011, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(997, self, varargin{:});
     end
     function varargout = toString(self,varargin)
     %Usage: retval = toString (precision = -1)
     %
     %precision is of type int. precision is of type int. retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(1012, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(998, self, varargin{:});
     end
     function varargout = toString_c(self,varargin)
     %Usage: retval = toString_c ()
     %
     %retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(1013, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(999, self, varargin{:});
     end
     function varargout = data(self,varargin)
     %Usage: retval = data ()
     %
     %retval is of type double const *. 
-      [varargout{1:nargout}] = yarpMEX(1014, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1000, self, varargin{:});
     end
     function varargout = isEqual(self,varargin)
     %Usage: retval = isEqual (r)
     %
     %r is of type Matrix. r is of type Matrix. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1015, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1001, self, varargin{:});
     end
     function varargout = read(self,varargin)
     %Usage: retval = read (connection)
     %
     %connection is of type ConnectionReader. connection is of type ConnectionReader. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1016, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1002, self, varargin{:});
     end
     function varargout = write(self,varargin)
     %Usage: retval = write (connection)
     %
     %connection is of type ConnectionWriter. connection is of type ConnectionWriter. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1017, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1003, self, varargin{:});
     end
     function varargout = get(self,varargin)
     %Usage: retval = get (i, j)
     %
     %i is of type int. j is of type int. i is of type int. j is of type int. retval is of type double. 
-      [varargout{1:nargout}] = yarpMEX(1018, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1004, self, varargin{:});
     end
     function varargout = set(self,varargin)
     %Usage: set (i, j, v)
     %
     %i is of type int. j is of type int. v is of type double. 
-      [varargout{1:nargout}] = yarpMEX(1019, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1005, self, varargin{:});
     end
   end
   methods(Static)

--- a/matlab/autogenerated/+yarp/Matrix.m
+++ b/matlab/autogenerated/+yarp/Matrix.m
@@ -1,11 +1,9 @@
-classdef Matrix < SwigRef
+classdef Matrix < yarp.Portable
     %Usage: Matrix ()
     %
   methods
-    function this = swig_this(self)
-      this = yarpMEX(3, self);
-    end
     function self = Matrix(varargin)
+      self@yarp.Portable(SwigRef.Null);
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;

--- a/matlab/autogenerated/+yarp/MotorTorqueParameters.m
+++ b/matlab/autogenerated/+yarp/MotorTorqueParameters.m
@@ -9,40 +9,40 @@ classdef MotorTorqueParameters < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(1613, self);
+        varargout{1} = yarpMEX(1599, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(1614, self, varargin{1});
+        yarpMEX(1600, self, varargin{1});
       end
     end
     function varargout = bemf_scale(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(1615, self);
+        varargout{1} = yarpMEX(1601, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(1616, self, varargin{1});
+        yarpMEX(1602, self, varargin{1});
       end
     end
     function varargout = ktau(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(1617, self);
+        varargout{1} = yarpMEX(1603, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(1618, self, varargin{1});
+        yarpMEX(1604, self, varargin{1});
       end
     end
     function varargout = ktau_scale(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(1619, self);
+        varargout{1} = yarpMEX(1605, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(1620, self, varargin{1});
+        yarpMEX(1606, self, varargin{1});
       end
     end
     function self = MotorTorqueParameters(varargin)
@@ -51,14 +51,14 @@ classdef MotorTorqueParameters < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(1621, varargin{:});
+        tmp = yarpMEX(1607, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1622, self);
+        yarpMEX(1608, self);
         self.SwigClear();
       end
     end

--- a/matlab/autogenerated/+yarp/NameStore.m
+++ b/matlab/autogenerated/+yarp/NameStore.m
@@ -7,7 +7,7 @@ classdef NameStore < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(601, self);
+        yarpMEX(589, self);
         self.SwigClear();
       end
     end
@@ -15,19 +15,19 @@ classdef NameStore < SwigRef
     %Usage: retval = query (name)
     %
     %name is of type std::string const &. name is of type std::string const &. retval is of type Contact. 
-      [varargout{1:nargout}] = yarpMEX(602, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(590, self, varargin{:});
     end
     function varargout = announce(self,varargin)
     %Usage: retval = announce (name, activity)
     %
     %name is of type std::string const &. activity is of type int. name is of type std::string const &. activity is of type int. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(603, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(591, self, varargin{:});
     end
     function varargout = process(self,varargin)
     %Usage: retval = process (in, out, source)
     %
     %in is of type PortWriter. out is of type PortReader. source is of type Contact. in is of type PortWriter. out is of type PortReader. source is of type Contact. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(604, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(592, self, varargin{:});
     end
     function self = NameStore(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/Network.m
+++ b/matlab/autogenerated/+yarp/Network.m
@@ -1,11 +1,9 @@
-classdef Network < SwigRef
+classdef Network < yarp.NetworkBase
     %Usage: Network ()
     %
   methods
-    function this = swig_this(self)
-      this = yarpMEX(3, self);
-    end
     function self = Network(varargin)
+      self@yarp.NetworkBase(SwigRef.Null);
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;

--- a/matlab/autogenerated/+yarp/Network.m
+++ b/matlab/autogenerated/+yarp/Network.m
@@ -9,14 +9,14 @@ classdef Network < yarp.NetworkBase
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(391, varargin{:});
+        tmp = yarpMEX(379, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(392, self);
+        yarpMEX(380, self);
         self.SwigClear();
       end
     end
@@ -26,12 +26,12 @@ classdef Network < yarp.NetworkBase
     %Usage: init (clockType)
     %
     %clockType is of type yarp::os::yarpClockType. 
-     [varargout{1:nargout}] = yarpMEX(393, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(381, varargin{:});
     end
     function varargout = fini(varargin)
     %Usage: fini ()
     %
-     [varargout{1:nargout}] = yarpMEX(394, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(382, varargin{:});
     end
   end
 end

--- a/matlab/autogenerated/+yarp/NetworkBase.m
+++ b/matlab/autogenerated/+yarp/NetworkBase.m
@@ -11,14 +11,14 @@ classdef NetworkBase < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(389, varargin{:});
+        tmp = yarpMEX(377, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(390, self);
+        yarpMEX(378, self);
         self.SwigClear();
       end
     end
@@ -28,304 +28,304 @@ classdef NetworkBase < SwigRef
     %Usage: initMinimum (clockType)
     %
     %clockType is of type yarp::os::yarpClockType. 
-     [varargout{1:nargout}] = yarpMEX(338, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(326, varargin{:});
     end
     function varargout = autoInitMinimum(varargin)
     %Usage: autoInitMinimum (clockType)
     %
     %clockType is of type yarp::os::yarpClockType. 
-     [varargout{1:nargout}] = yarpMEX(339, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(327, varargin{:});
     end
     function varargout = yarpClockInit(varargin)
     %Usage: yarpClockInit (clockType)
     %
     %clockType is of type yarp::os::yarpClockType. 
-     [varargout{1:nargout}] = yarpMEX(340, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(328, varargin{:});
     end
     function varargout = finiMinimum(varargin)
     %Usage: finiMinimum ()
     %
-     [varargout{1:nargout}] = yarpMEX(341, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(329, varargin{:});
     end
     function varargout = connect(varargin)
     %Usage: retval = connect (src, dest, style)
     %
     %src is of type std::string const &. dest is of type std::string const &. style is of type ContactStyle. src is of type std::string const &. dest is of type std::string const &. style is of type ContactStyle. retval is of type bool. 
-     [varargout{1:nargout}] = yarpMEX(342, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(330, varargin{:});
     end
     function varargout = disconnect(varargin)
     %Usage: retval = disconnect (src, dest, style)
     %
     %src is of type std::string const &. dest is of type std::string const &. style is of type ContactStyle. src is of type std::string const &. dest is of type std::string const &. style is of type ContactStyle. retval is of type bool. 
-     [varargout{1:nargout}] = yarpMEX(343, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(331, varargin{:});
     end
     function varargout = isConnected(varargin)
     %Usage: retval = isConnected (src, dest, style)
     %
     %src is of type std::string const &. dest is of type std::string const &. style is of type ContactStyle. src is of type std::string const &. dest is of type std::string const &. style is of type ContactStyle. retval is of type bool. 
-     [varargout{1:nargout}] = yarpMEX(344, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(332, varargin{:});
     end
     function varargout = exists(varargin)
     %Usage: retval = exists (port, style)
     %
     %port is of type std::string const &. style is of type ContactStyle. port is of type std::string const &. style is of type ContactStyle. retval is of type bool. 
-     [varargout{1:nargout}] = yarpMEX(345, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(333, varargin{:});
     end
     function varargout = sync(varargin)
     %Usage: retval = sync (port)
     %
     %port is of type std::string const &. port is of type std::string const &. retval is of type bool. 
-     [varargout{1:nargout}] = yarpMEX(346, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(334, varargin{:});
     end
     function varargout = assertion(varargin)
     %Usage: assertion (shouldBeTrue)
     %
     %shouldBeTrue is of type bool. 
-     [varargout{1:nargout}] = yarpMEX(347, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(335, varargin{:});
     end
     function varargout = queryName(varargin)
     %Usage: retval = queryName (name)
     %
     %name is of type std::string const &. name is of type std::string const &. retval is of type Contact. 
-     [varargout{1:nargout}] = yarpMEX(348, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(336, varargin{:});
     end
     function varargout = registerName(varargin)
     %Usage: retval = registerName (name)
     %
     %name is of type std::string const &. name is of type std::string const &. retval is of type Contact. 
-     [varargout{1:nargout}] = yarpMEX(349, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(337, varargin{:});
     end
     function varargout = registerContact(varargin)
     %Usage: retval = registerContact (contact)
     %
     %contact is of type Contact. contact is of type Contact. retval is of type Contact. 
-     [varargout{1:nargout}] = yarpMEX(350, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(338, varargin{:});
     end
     function varargout = unregisterName(varargin)
     %Usage: retval = unregisterName (name)
     %
     %name is of type std::string const &. name is of type std::string const &. retval is of type Contact. 
-     [varargout{1:nargout}] = yarpMEX(351, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(339, varargin{:});
     end
     function varargout = unregisterContact(varargin)
     %Usage: retval = unregisterContact (contact)
     %
     %contact is of type Contact. contact is of type Contact. retval is of type Contact. 
-     [varargout{1:nargout}] = yarpMEX(352, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(340, varargin{:});
     end
     function varargout = setProperty(varargin)
     %Usage: retval = setProperty (name, key, value)
     %
     %name is of type char const *. key is of type char const *. value is of type Value. name is of type char const *. key is of type char const *. value is of type Value. retval is of type bool. 
-     [varargout{1:nargout}] = yarpMEX(353, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(341, varargin{:});
     end
     function varargout = getProperty(varargin)
     %Usage: retval = getProperty (name, key)
     %
     %name is of type char const *. key is of type char const *. name is of type char const *. key is of type char const *. retval is of type Value. 
-     [varargout{1:nargout}] = yarpMEX(354, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(342, varargin{:});
     end
     function varargout = getNameServerName(varargin)
     %Usage: retval = getNameServerName ()
     %
     %retval is of type std::string. 
-     [varargout{1:nargout}] = yarpMEX(355, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(343, varargin{:});
     end
     function varargout = getNameServerContact(varargin)
     %Usage: retval = getNameServerContact ()
     %
     %retval is of type Contact. 
-     [varargout{1:nargout}] = yarpMEX(356, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(344, varargin{:});
     end
     function varargout = setNameServerName(varargin)
     %Usage: retval = setNameServerName (name)
     %
     %name is of type std::string const &. name is of type std::string const &. retval is of type bool. 
-     [varargout{1:nargout}] = yarpMEX(357, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(345, varargin{:});
     end
     function varargout = setLocalMode(varargin)
     %Usage: retval = setLocalMode (flag)
     %
     %flag is of type bool. flag is of type bool. retval is of type bool. 
-     [varargout{1:nargout}] = yarpMEX(358, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(346, varargin{:});
     end
     function varargout = getLocalMode(varargin)
     %Usage: retval = getLocalMode ()
     %
     %retval is of type bool. 
-     [varargout{1:nargout}] = yarpMEX(359, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(347, varargin{:});
     end
     function varargout = readString(varargin)
     %Usage: retval = readString ()
     %
     %retval is of type std::string. 
-     [varargout{1:nargout}] = yarpMEX(360, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(348, varargin{:});
     end
     function varargout = writeToNameServer(varargin)
     %Usage: retval = writeToNameServer (cmd, reply, style)
     %
     %cmd is of type PortWriter. reply is of type PortReader. style is of type ContactStyle. cmd is of type PortWriter. reply is of type PortReader. style is of type ContactStyle. retval is of type bool. 
-     [varargout{1:nargout}] = yarpMEX(361, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(349, varargin{:});
     end
     function varargout = write(varargin)
     %Usage: retval = write (port_name, cmd, reply)
     %
     %port_name is of type std::string const &. cmd is of type PortWriter. reply is of type PortReader. port_name is of type std::string const &. cmd is of type PortWriter. reply is of type PortReader. retval is of type bool. 
-     [varargout{1:nargout}] = yarpMEX(362, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(350, varargin{:});
     end
     function varargout = checkNetwork(varargin)
     %Usage: retval = checkNetwork (timeout)
     %
     %timeout is of type double. timeout is of type double. retval is of type bool. 
-     [varargout{1:nargout}] = yarpMEX(363, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(351, varargin{:});
     end
     function varargout = initialized(varargin)
     %Usage: retval = initialized ()
     %
     %retval is of type bool. 
-     [varargout{1:nargout}] = yarpMEX(364, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(352, varargin{:});
     end
     function varargout = setVerbosity(varargin)
     %Usage: setVerbosity (verbosity)
     %
     %verbosity is of type int. 
-     [varargout{1:nargout}] = yarpMEX(365, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(353, varargin{:});
     end
     function varargout = queryBypass(varargin)
     %Usage: queryBypass (store)
     %
     %store is of type NameStore *. 
-     [varargout{1:nargout}] = yarpMEX(366, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(354, varargin{:});
     end
     function varargout = getQueryBypass(varargin)
     %Usage: retval = getQueryBypass ()
     %
     %retval is of type NameStore *. 
-     [varargout{1:nargout}] = yarpMEX(367, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(355, varargin{:});
     end
     function varargout = getEnvironment(varargin)
     %Usage: retval = getEnvironment (key)
     %
     %key is of type char const *. key is of type char const *. retval is of type std::string. 
-     [varargout{1:nargout}] = yarpMEX(368, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(356, varargin{:});
     end
     function varargout = setEnvironment(varargin)
     %Usage: setEnvironment (key, val)
     %
     %key is of type std::string const &. val is of type std::string const &. 
-     [varargout{1:nargout}] = yarpMEX(369, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(357, varargin{:});
     end
     function varargout = unsetEnvironment(varargin)
     %Usage: unsetEnvironment (key)
     %
     %key is of type std::string const &. 
-     [varargout{1:nargout}] = yarpMEX(370, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(358, varargin{:});
     end
     function varargout = getDirectorySeparator(varargin)
     %Usage: retval = getDirectorySeparator ()
     %
     %retval is of type std::string. 
-     [varargout{1:nargout}] = yarpMEX(371, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(359, varargin{:});
     end
     function varargout = getPathSeparator(varargin)
     %Usage: retval = getPathSeparator ()
     %
     %retval is of type std::string. 
-     [varargout{1:nargout}] = yarpMEX(372, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(360, varargin{:});
     end
     function varargout = registerCarrier(varargin)
     %Usage: retval = registerCarrier (name, dll)
     %
     %name is of type char const *. dll is of type char const *. name is of type char const *. dll is of type char const *. retval is of type bool. 
-     [varargout{1:nargout}] = yarpMEX(373, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(361, varargin{:});
     end
     function varargout = lock(varargin)
     %Usage: lock ()
     %
-     [varargout{1:nargout}] = yarpMEX(374, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(362, varargin{:});
     end
     function varargout = unlock(varargin)
     %Usage: unlock ()
     %
-     [varargout{1:nargout}] = yarpMEX(375, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(363, varargin{:});
     end
     function varargout = localNetworkAllocation(varargin)
     %Usage: retval = localNetworkAllocation ()
     %
     %retval is of type bool. 
-     [varargout{1:nargout}] = yarpMEX(376, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(364, varargin{:});
     end
     function varargout = detectNameServer(varargin)
     %Usage: retval = detectNameServer (useDetectedServer, scanNeeded, serverUsed)
     %
     %useDetectedServer is of type bool. scanNeeded is of type bool &. serverUsed is of type bool &. useDetectedServer is of type bool. scanNeeded is of type bool &. serverUsed is of type bool &. retval is of type Contact. 
-     [varargout{1:nargout}] = yarpMEX(377, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(365, varargin{:});
     end
     function varargout = setNameServerContact(varargin)
     %Usage: retval = setNameServerContact (nameServerContact)
     %
     %nameServerContact is of type Contact. nameServerContact is of type Contact. retval is of type bool. 
-     [varargout{1:nargout}] = yarpMEX(378, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(366, varargin{:});
     end
     function varargout = getConfigFile(varargin)
     %Usage: retval = getConfigFile (fname)
     %
     %fname is of type char const *. fname is of type char const *. retval is of type std::string. 
-     [varargout{1:nargout}] = yarpMEX(379, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(367, varargin{:});
     end
     function varargout = getDefaultPortRange(varargin)
     %Usage: retval = getDefaultPortRange ()
     %
     %retval is of type int. 
-     [varargout{1:nargout}] = yarpMEX(380, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(368, varargin{:});
     end
     function varargout = setConnectionQos(varargin)
     %Usage: retval = setConnectionQos (src, dest, style)
     %
     %src is of type std::string const &. dest is of type std::string const &. style is of type QosStyle. src is of type std::string const &. dest is of type std::string const &. style is of type QosStyle. retval is of type bool. 
-     [varargout{1:nargout}] = yarpMEX(381, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(369, varargin{:});
     end
     function varargout = getConnectionQos(varargin)
     %Usage: retval = getConnectionQos (src, dest, srcStyle, destStyle)
     %
     %src is of type std::string const &. dest is of type std::string const &. srcStyle is of type QosStyle. destStyle is of type QosStyle. src is of type std::string const &. dest is of type std::string const &. srcStyle is of type QosStyle. destStyle is of type QosStyle. retval is of type bool. 
-     [varargout{1:nargout}] = yarpMEX(382, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(370, varargin{:});
     end
     function varargout = isValidPortName(varargin)
     %Usage: retval = isValidPortName (portName)
     %
     %portName is of type std::string const &. portName is of type std::string const &. retval is of type bool. 
-     [varargout{1:nargout}] = yarpMEX(383, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(371, varargin{:});
     end
     function varargout = waitConnection(varargin)
     %Usage: retval = waitConnection (source, destination)
     %
     %source is of type std::string const &. destination is of type std::string const &. source is of type std::string const &. destination is of type std::string const &. retval is of type bool. 
-     [varargout{1:nargout}] = yarpMEX(384, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(372, varargin{:});
     end
     function varargout = waitPort(varargin)
     %Usage: retval = waitPort (target)
     %
     %target is of type std::string const &. target is of type std::string const &. retval is of type bool. 
-     [varargout{1:nargout}] = yarpMEX(385, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(373, varargin{:});
     end
     function varargout = sendMessage(varargin)
     %Usage: retval = sendMessage (port, writable, output, quiet)
     %
     %port is of type std::string const &. writable is of type PortWriter. output is of type std::string &. quiet is of type bool. port is of type std::string const &. writable is of type PortWriter. output is of type std::string &. quiet is of type bool. retval is of type int. 
-     [varargout{1:nargout}] = yarpMEX(386, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(374, varargin{:});
     end
     function varargout = disconnectInput(varargin)
     %Usage: retval = disconnectInput (src, dest)
     %
     %src is of type std::string const &. dest is of type std::string const &. src is of type std::string const &. dest is of type std::string const &. retval is of type int. 
-     [varargout{1:nargout}] = yarpMEX(387, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(375, varargin{:});
     end
     function varargout = poll(varargin)
     %Usage: retval = poll (target)
     %
     %target is of type std::string const &. target is of type std::string const &. retval is of type int. 
-     [varargout{1:nargout}] = yarpMEX(388, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(376, varargin{:});
     end
   end
 end

--- a/matlab/autogenerated/+yarp/PAD_BYTES.m
+++ b/matlab/autogenerated/+yarp/PAD_BYTES.m
@@ -2,5 +2,5 @@ function varargout = PAD_BYTES(varargin)
     %Usage: retval = PAD_BYTES (len, pad)
     %
     %len is of type size_t. pad is of type size_t. len is of type size_t. pad is of type size_t. retval is of type int. 
-  [varargout{1:nargout}] = yarpMEX(857, varargin{:});
+  [varargout{1:nargout}] = yarpMEX(843, varargin{:});
 end

--- a/matlab/autogenerated/+yarp/PeriodicThread.m
+++ b/matlab/autogenerated/+yarp/PeriodicThread.m
@@ -7,7 +7,7 @@ classdef PeriodicThread < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(507, self);
+        yarpMEX(495, self);
         self.SwigClear();
       end
     end
@@ -15,97 +15,97 @@ classdef PeriodicThread < SwigRef
     %Usage: retval = start ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(508, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(496, self, varargin{:});
     end
     function varargout = step(self,varargin)
     %Usage: step ()
     %
-      [varargout{1:nargout}] = yarpMEX(509, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(497, self, varargin{:});
     end
     function varargout = stop(self,varargin)
     %Usage: stop ()
     %
-      [varargout{1:nargout}] = yarpMEX(510, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(498, self, varargin{:});
     end
     function varargout = askToStop(self,varargin)
     %Usage: askToStop ()
     %
-      [varargout{1:nargout}] = yarpMEX(511, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(499, self, varargin{:});
     end
     function varargout = isRunning(self,varargin)
     %Usage: retval = isRunning ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(512, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(500, self, varargin{:});
     end
     function varargout = isSuspended(self,varargin)
     %Usage: retval = isSuspended ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(513, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(501, self, varargin{:});
     end
     function varargout = setPeriod(self,varargin)
     %Usage: retval = setPeriod (period)
     %
     %period is of type double. period is of type double. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(514, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(502, self, varargin{:});
     end
     function varargout = getPeriod(self,varargin)
     %Usage: retval = getPeriod ()
     %
     %retval is of type double. 
-      [varargout{1:nargout}] = yarpMEX(515, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(503, self, varargin{:});
     end
     function varargout = suspend(self,varargin)
     %Usage: suspend ()
     %
-      [varargout{1:nargout}] = yarpMEX(516, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(504, self, varargin{:});
     end
     function varargout = resume(self,varargin)
     %Usage: resume ()
     %
-      [varargout{1:nargout}] = yarpMEX(517, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(505, self, varargin{:});
     end
     function varargout = resetStat(self,varargin)
     %Usage: resetStat ()
     %
-      [varargout{1:nargout}] = yarpMEX(518, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(506, self, varargin{:});
     end
     function varargout = getEstimatedPeriod(self,varargin)
     %Usage: getEstimatedPeriod (av, std)
     %
     %av is of type double &. std is of type double &. 
-      [varargout{1:nargout}] = yarpMEX(519, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(507, self, varargin{:});
     end
     function varargout = getIterations(self,varargin)
     %Usage: retval = getIterations ()
     %
     %retval is of type unsigned int. 
-      [varargout{1:nargout}] = yarpMEX(520, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(508, self, varargin{:});
     end
     function varargout = getEstimatedUsed(self,varargin)
     %Usage: getEstimatedUsed (av, std)
     %
     %av is of type double &. std is of type double &. 
-      [varargout{1:nargout}] = yarpMEX(521, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(509, self, varargin{:});
     end
     function varargout = setPriority(self,varargin)
     %Usage: retval = setPriority (priority)
     %
     %priority is of type int. priority is of type int. retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(522, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(510, self, varargin{:});
     end
     function varargout = getPriority(self,varargin)
     %Usage: retval = getPriority ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(523, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(511, self, varargin{:});
     end
     function varargout = getPolicy(self,varargin)
     %Usage: retval = getPolicy ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(524, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(512, self, varargin{:});
     end
     function self = PeriodicThread(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/Pid.m
+++ b/matlab/autogenerated/+yarp/Pid.m
@@ -9,13 +9,83 @@ classdef Pid < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
+        varargout{1} = yarpMEX(1294, self);
+      else
+        nargoutchk(0, 0)
+        yarpMEX(1295, self, varargin{1});
+      end
+    end
+    function varargout = kd(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = yarpMEX(1296, self);
+      else
+        nargoutchk(0, 0)
+        yarpMEX(1297, self, varargin{1});
+      end
+    end
+    function varargout = ki(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = yarpMEX(1298, self);
+      else
+        nargoutchk(0, 0)
+        yarpMEX(1299, self, varargin{1});
+      end
+    end
+    function varargout = max_int(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = yarpMEX(1300, self);
+      else
+        nargoutchk(0, 0)
+        yarpMEX(1301, self, varargin{1});
+      end
+    end
+    function varargout = scale(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = yarpMEX(1302, self);
+      else
+        nargoutchk(0, 0)
+        yarpMEX(1303, self, varargin{1});
+      end
+    end
+    function varargout = max_output(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = yarpMEX(1304, self);
+      else
+        nargoutchk(0, 0)
+        yarpMEX(1305, self, varargin{1});
+      end
+    end
+    function varargout = offset(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
+        varargout{1} = yarpMEX(1306, self);
+      else
+        nargoutchk(0, 0)
+        yarpMEX(1307, self, varargin{1});
+      end
+    end
+    function varargout = stiction_up_val(self, varargin)
+      narginchk(1, 2)
+      if nargin==1
+        nargoutchk(0, 1)
         varargout{1} = yarpMEX(1308, self);
       else
         nargoutchk(0, 0)
         yarpMEX(1309, self, varargin{1});
       end
     end
-    function varargout = kd(self, varargin)
+    function varargout = stiction_down_val(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -25,7 +95,7 @@ classdef Pid < SwigRef
         yarpMEX(1311, self, varargin{1});
       end
     end
-    function varargout = ki(self, varargin)
+    function varargout = kff(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
@@ -35,79 +105,9 @@ classdef Pid < SwigRef
         yarpMEX(1313, self, varargin{1});
       end
     end
-    function varargout = max_int(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = yarpMEX(1314, self);
-      else
-        nargoutchk(0, 0)
-        yarpMEX(1315, self, varargin{1});
-      end
-    end
-    function varargout = scale(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = yarpMEX(1316, self);
-      else
-        nargoutchk(0, 0)
-        yarpMEX(1317, self, varargin{1});
-      end
-    end
-    function varargout = max_output(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = yarpMEX(1318, self);
-      else
-        nargoutchk(0, 0)
-        yarpMEX(1319, self, varargin{1});
-      end
-    end
-    function varargout = offset(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = yarpMEX(1320, self);
-      else
-        nargoutchk(0, 0)
-        yarpMEX(1321, self, varargin{1});
-      end
-    end
-    function varargout = stiction_up_val(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = yarpMEX(1322, self);
-      else
-        nargoutchk(0, 0)
-        yarpMEX(1323, self, varargin{1});
-      end
-    end
-    function varargout = stiction_down_val(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = yarpMEX(1324, self);
-      else
-        nargoutchk(0, 0)
-        yarpMEX(1325, self, varargin{1});
-      end
-    end
-    function varargout = kff(self, varargin)
-      narginchk(1, 2)
-      if nargin==1
-        nargoutchk(0, 1)
-        varargout{1} = yarpMEX(1326, self);
-      else
-        nargoutchk(0, 0)
-        yarpMEX(1327, self, varargin{1});
-      end
-    end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1328, self);
+        yarpMEX(1314, self);
         self.SwigClear();
       end
     end
@@ -117,7 +117,7 @@ classdef Pid < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(1329, varargin{:});
+        tmp = yarpMEX(1315, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
@@ -126,30 +126,30 @@ classdef Pid < SwigRef
     %Usage: setMaxInt (m)
     %
     %m is of type double. 
-      [varargout{1:nargout}] = yarpMEX(1330, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1316, self, varargin{:});
     end
     function varargout = setMaxOut(self,varargin)
     %Usage: setMaxOut (m)
     %
     %m is of type double. 
-      [varargout{1:nargout}] = yarpMEX(1331, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1317, self, varargin{:});
     end
     function varargout = setStictionValues(self,varargin)
     %Usage: setStictionValues (up_value, down_value)
     %
     %up_value is of type double. down_value is of type double. 
-      [varargout{1:nargout}] = yarpMEX(1332, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1318, self, varargin{:});
     end
     function varargout = isEqual(self,varargin)
     %Usage: retval = isEqual (p)
     %
     %p is of type Pid. p is of type Pid. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1333, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1319, self, varargin{:});
     end
     function varargout = clear(self,varargin)
     %Usage: clear ()
     %
-      [varargout{1:nargout}] = yarpMEX(1334, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1320, self, varargin{:});
     end
   end
   methods(Static)

--- a/matlab/autogenerated/+yarp/PidVector.m
+++ b/matlab/autogenerated/+yarp/PidVector.m
@@ -9,89 +9,89 @@ classdef PidVector < SwigRef
     %Usage: retval = pop ()
     %
     %retval is of type Pid. 
-      [varargout{1:nargout}] = yarpMEX(1890, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1876, self, varargin{:});
     end
     function varargout = brace(self,varargin)
     %Usage: retval = brace (i)
     %
     %i is of type std::vector< yarp::dev::Pid >::difference_type. i is of type std::vector< yarp::dev::Pid >::difference_type. retval is of type Pid. 
-      [varargout{1:nargout}] = yarpMEX(1891, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1877, self, varargin{:});
     end
     function varargout = setbrace(self,varargin)
     %Usage: setbrace (x, i)
     %
     %x is of type Pid. i is of type std::vector< yarp::dev::Pid >::difference_type. 
-      [varargout{1:nargout}] = yarpMEX(1892, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1878, self, varargin{:});
     end
     function varargout = append(self,varargin)
     %Usage: append (x)
     %
     %x is of type Pid. 
-      [varargout{1:nargout}] = yarpMEX(1893, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1879, self, varargin{:});
     end
     function varargout = empty(self,varargin)
     %Usage: retval = empty ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1894, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1880, self, varargin{:});
     end
     function varargout = size(self,varargin)
     %Usage: retval = size ()
     %
     %retval is of type std::vector< yarp::dev::Pid >::size_type. 
-      [varargout{1:nargout}] = yarpMEX(1895, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1881, self, varargin{:});
     end
     function varargout = swap(self,varargin)
     %Usage: swap (v)
     %
     %v is of type PidVector. 
-      [varargout{1:nargout}] = yarpMEX(1896, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1882, self, varargin{:});
     end
     function varargout = begin(self,varargin)
     %Usage: retval = begin ()
     %
     %retval is of type std::vector< yarp::dev::Pid >::iterator. 
-      [varargout{1:nargout}] = yarpMEX(1897, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1883, self, varargin{:});
     end
     function varargout = end(self,varargin)
     %Usage: retval = end ()
     %
     %retval is of type std::vector< yarp::dev::Pid >::iterator. 
-      [varargout{1:nargout}] = yarpMEX(1898, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1884, self, varargin{:});
     end
     function varargout = rbegin(self,varargin)
     %Usage: retval = rbegin ()
     %
     %retval is of type std::vector< yarp::dev::Pid >::reverse_iterator. 
-      [varargout{1:nargout}] = yarpMEX(1899, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1885, self, varargin{:});
     end
     function varargout = rend(self,varargin)
     %Usage: retval = rend ()
     %
     %retval is of type std::vector< yarp::dev::Pid >::reverse_iterator. 
-      [varargout{1:nargout}] = yarpMEX(1900, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1886, self, varargin{:});
     end
     function varargout = clear(self,varargin)
     %Usage: clear ()
     %
-      [varargout{1:nargout}] = yarpMEX(1901, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1887, self, varargin{:});
     end
     function varargout = get_allocator(self,varargin)
     %Usage: retval = get_allocator ()
     %
     %retval is of type std::vector< yarp::dev::Pid >::allocator_type. 
-      [varargout{1:nargout}] = yarpMEX(1902, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1888, self, varargin{:});
     end
     function varargout = pop_back(self,varargin)
     %Usage: pop_back ()
     %
-      [varargout{1:nargout}] = yarpMEX(1903, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1889, self, varargin{:});
     end
     function varargout = erase(self,varargin)
     %Usage: retval = erase (first, last)
     %
     %first is of type std::vector< yarp::dev::Pid >::iterator. last is of type std::vector< yarp::dev::Pid >::iterator. first is of type std::vector< yarp::dev::Pid >::iterator. last is of type std::vector< yarp::dev::Pid >::iterator. retval is of type std::vector< yarp::dev::Pid >::iterator. 
-      [varargout{1:nargout}] = yarpMEX(1904, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1890, self, varargin{:});
     end
     function self = PidVector(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -99,7 +99,7 @@ classdef PidVector < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(1905, varargin{:});
+        tmp = yarpMEX(1891, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
@@ -108,53 +108,53 @@ classdef PidVector < SwigRef
     %Usage: push_back (x)
     %
     %x is of type Pid. 
-      [varargout{1:nargout}] = yarpMEX(1906, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1892, self, varargin{:});
     end
     function varargout = front(self,varargin)
     %Usage: retval = front ()
     %
     %retval is of type Pid. 
-      [varargout{1:nargout}] = yarpMEX(1907, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1893, self, varargin{:});
     end
     function varargout = back(self,varargin)
     %Usage: retval = back ()
     %
     %retval is of type Pid. 
-      [varargout{1:nargout}] = yarpMEX(1908, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1894, self, varargin{:});
     end
     function varargout = assign(self,varargin)
     %Usage: assign (n, x)
     %
     %n is of type std::vector< yarp::dev::Pid >::size_type. x is of type Pid. 
-      [varargout{1:nargout}] = yarpMEX(1909, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1895, self, varargin{:});
     end
     function varargout = resize(self,varargin)
     %Usage: resize (new_size, x)
     %
     %new_size is of type std::vector< yarp::dev::Pid >::size_type. x is of type Pid. 
-      [varargout{1:nargout}] = yarpMEX(1910, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1896, self, varargin{:});
     end
     function varargout = insert(self,varargin)
     %Usage: insert (pos, n, x)
     %
     %pos is of type std::vector< yarp::dev::Pid >::iterator. n is of type std::vector< yarp::dev::Pid >::size_type. x is of type Pid. 
-      [varargout{1:nargout}] = yarpMEX(1911, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1897, self, varargin{:});
     end
     function varargout = reserve(self,varargin)
     %Usage: reserve (n)
     %
     %n is of type std::vector< yarp::dev::Pid >::size_type. 
-      [varargout{1:nargout}] = yarpMEX(1912, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1898, self, varargin{:});
     end
     function varargout = capacity(self,varargin)
     %Usage: retval = capacity ()
     %
     %retval is of type std::vector< yarp::dev::Pid >::size_type. 
-      [varargout{1:nargout}] = yarpMEX(1913, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1899, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1914, self);
+        yarpMEX(1900, self);
         self.SwigClear();
       end
     end

--- a/matlab/autogenerated/+yarp/PixelBgr.m
+++ b/matlab/autogenerated/+yarp/PixelBgr.m
@@ -9,30 +9,30 @@ classdef PixelBgr < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(917, self);
+        varargout{1} = yarpMEX(903, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(918, self, varargin{1});
+        yarpMEX(904, self, varargin{1});
       end
     end
     function varargout = g(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(919, self);
+        varargout{1} = yarpMEX(905, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(920, self, varargin{1});
+        yarpMEX(906, self, varargin{1});
       end
     end
     function varargout = r(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(921, self);
+        varargout{1} = yarpMEX(907, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(922, self, varargin{1});
+        yarpMEX(908, self, varargin{1});
       end
     end
     function self = PixelBgr(varargin)
@@ -41,14 +41,14 @@ classdef PixelBgr < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(923, varargin{:});
+        tmp = yarpMEX(909, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(924, self);
+        yarpMEX(910, self);
         self.SwigClear();
       end
     end

--- a/matlab/autogenerated/+yarp/PixelBgra.m
+++ b/matlab/autogenerated/+yarp/PixelBgra.m
@@ -9,40 +9,40 @@ classdef PixelBgra < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(907, self);
+        varargout{1} = yarpMEX(893, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(908, self, varargin{1});
+        yarpMEX(894, self, varargin{1});
       end
     end
     function varargout = g(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(909, self);
+        varargout{1} = yarpMEX(895, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(910, self, varargin{1});
+        yarpMEX(896, self, varargin{1});
       end
     end
     function varargout = r(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(911, self);
+        varargout{1} = yarpMEX(897, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(912, self, varargin{1});
+        yarpMEX(898, self, varargin{1});
       end
     end
     function varargout = a(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(913, self);
+        varargout{1} = yarpMEX(899, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(914, self, varargin{1});
+        yarpMEX(900, self, varargin{1});
       end
     end
     function self = PixelBgra(varargin)
@@ -51,14 +51,14 @@ classdef PixelBgra < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(915, varargin{:});
+        tmp = yarpMEX(901, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(916, self);
+        yarpMEX(902, self);
         self.SwigClear();
       end
     end

--- a/matlab/autogenerated/+yarp/PixelHsv.m
+++ b/matlab/autogenerated/+yarp/PixelHsv.m
@@ -9,30 +9,30 @@ classdef PixelHsv < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(925, self);
+        varargout{1} = yarpMEX(911, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(926, self, varargin{1});
+        yarpMEX(912, self, varargin{1});
       end
     end
     function varargout = s(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(927, self);
+        varargout{1} = yarpMEX(913, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(928, self, varargin{1});
+        yarpMEX(914, self, varargin{1});
       end
     end
     function varargout = v(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(929, self);
+        varargout{1} = yarpMEX(915, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(930, self, varargin{1});
+        yarpMEX(916, self, varargin{1});
       end
     end
     function self = PixelHsv(varargin)
@@ -41,14 +41,14 @@ classdef PixelHsv < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(931, varargin{:});
+        tmp = yarpMEX(917, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(932, self);
+        yarpMEX(918, self);
         self.SwigClear();
       end
     end

--- a/matlab/autogenerated/+yarp/PixelHsvFloat.m
+++ b/matlab/autogenerated/+yarp/PixelHsvFloat.m
@@ -9,30 +9,30 @@ classdef PixelHsvFloat < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(957, self);
+        varargout{1} = yarpMEX(943, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(958, self, varargin{1});
+        yarpMEX(944, self, varargin{1});
       end
     end
     function varargout = s(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(959, self);
+        varargout{1} = yarpMEX(945, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(960, self, varargin{1});
+        yarpMEX(946, self, varargin{1});
       end
     end
     function varargout = v(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(961, self);
+        varargout{1} = yarpMEX(947, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(962, self, varargin{1});
+        yarpMEX(948, self, varargin{1});
       end
     end
     function self = PixelHsvFloat(varargin)
@@ -41,14 +41,14 @@ classdef PixelHsvFloat < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(963, varargin{:});
+        tmp = yarpMEX(949, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(964, self);
+        yarpMEX(950, self);
         self.SwigClear();
       end
     end

--- a/matlab/autogenerated/+yarp/PixelRgb.m
+++ b/matlab/autogenerated/+yarp/PixelRgb.m
@@ -9,30 +9,30 @@ classdef PixelRgb < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(889, self);
+        varargout{1} = yarpMEX(875, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(890, self, varargin{1});
+        yarpMEX(876, self, varargin{1});
       end
     end
     function varargout = g(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(891, self);
+        varargout{1} = yarpMEX(877, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(892, self, varargin{1});
+        yarpMEX(878, self, varargin{1});
       end
     end
     function varargout = b(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(893, self);
+        varargout{1} = yarpMEX(879, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(894, self, varargin{1});
+        yarpMEX(880, self, varargin{1});
       end
     end
     function self = PixelRgb(varargin)
@@ -41,14 +41,14 @@ classdef PixelRgb < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(895, varargin{:});
+        tmp = yarpMEX(881, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(896, self);
+        yarpMEX(882, self);
         self.SwigClear();
       end
     end

--- a/matlab/autogenerated/+yarp/PixelRgbFloat.m
+++ b/matlab/autogenerated/+yarp/PixelRgbFloat.m
@@ -9,30 +9,30 @@ classdef PixelRgbFloat < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(941, self);
+        varargout{1} = yarpMEX(927, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(942, self, varargin{1});
+        yarpMEX(928, self, varargin{1});
       end
     end
     function varargout = g(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(943, self);
+        varargout{1} = yarpMEX(929, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(944, self, varargin{1});
+        yarpMEX(930, self, varargin{1});
       end
     end
     function varargout = b(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(945, self);
+        varargout{1} = yarpMEX(931, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(946, self, varargin{1});
+        yarpMEX(932, self, varargin{1});
       end
     end
     function self = PixelRgbFloat(varargin)
@@ -41,14 +41,14 @@ classdef PixelRgbFloat < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(947, varargin{:});
+        tmp = yarpMEX(933, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(948, self);
+        yarpMEX(934, self);
         self.SwigClear();
       end
     end

--- a/matlab/autogenerated/+yarp/PixelRgbInt.m
+++ b/matlab/autogenerated/+yarp/PixelRgbInt.m
@@ -9,30 +9,30 @@ classdef PixelRgbInt < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(949, self);
+        varargout{1} = yarpMEX(935, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(950, self, varargin{1});
+        yarpMEX(936, self, varargin{1});
       end
     end
     function varargout = g(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(951, self);
+        varargout{1} = yarpMEX(937, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(952, self, varargin{1});
+        yarpMEX(938, self, varargin{1});
       end
     end
     function varargout = b(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(953, self);
+        varargout{1} = yarpMEX(939, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(954, self, varargin{1});
+        yarpMEX(940, self, varargin{1});
       end
     end
     function self = PixelRgbInt(varargin)
@@ -41,14 +41,14 @@ classdef PixelRgbInt < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(955, varargin{:});
+        tmp = yarpMEX(941, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(956, self);
+        yarpMEX(942, self);
         self.SwigClear();
       end
     end

--- a/matlab/autogenerated/+yarp/PixelRgbSigned.m
+++ b/matlab/autogenerated/+yarp/PixelRgbSigned.m
@@ -9,30 +9,30 @@ classdef PixelRgbSigned < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(933, self);
+        varargout{1} = yarpMEX(919, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(934, self, varargin{1});
+        yarpMEX(920, self, varargin{1});
       end
     end
     function varargout = g(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(935, self);
+        varargout{1} = yarpMEX(921, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(936, self, varargin{1});
+        yarpMEX(922, self, varargin{1});
       end
     end
     function varargout = b(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(937, self);
+        varargout{1} = yarpMEX(923, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(938, self, varargin{1});
+        yarpMEX(924, self, varargin{1});
       end
     end
     function self = PixelRgbSigned(varargin)
@@ -41,14 +41,14 @@ classdef PixelRgbSigned < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(939, varargin{:});
+        tmp = yarpMEX(925, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(940, self);
+        yarpMEX(926, self);
         self.SwigClear();
       end
     end

--- a/matlab/autogenerated/+yarp/PixelRgba.m
+++ b/matlab/autogenerated/+yarp/PixelRgba.m
@@ -9,40 +9,40 @@ classdef PixelRgba < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(897, self);
+        varargout{1} = yarpMEX(883, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(898, self, varargin{1});
+        yarpMEX(884, self, varargin{1});
       end
     end
     function varargout = g(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(899, self);
+        varargout{1} = yarpMEX(885, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(900, self, varargin{1});
+        yarpMEX(886, self, varargin{1});
       end
     end
     function varargout = b(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(901, self);
+        varargout{1} = yarpMEX(887, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(902, self, varargin{1});
+        yarpMEX(888, self, varargin{1});
       end
     end
     function varargout = a(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(903, self);
+        varargout{1} = yarpMEX(889, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(904, self, varargin{1});
+        yarpMEX(890, self, varargin{1});
       end
     end
     function self = PixelRgba(varargin)
@@ -51,14 +51,14 @@ classdef PixelRgba < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(905, varargin{:});
+        tmp = yarpMEX(891, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(906, self);
+        yarpMEX(892, self);
         self.SwigClear();
       end
     end

--- a/matlab/autogenerated/+yarp/PolyDriver.m
+++ b/matlab/autogenerated/+yarp/PolyDriver.m
@@ -1,11 +1,9 @@
-classdef PolyDriver < SwigRef
+classdef PolyDriver < yarp.DeviceDriver
     %Usage: PolyDriver ()
     %
   methods
-    function this = swig_this(self)
-      this = yarpMEX(3, self);
-    end
     function self = PolyDriver(varargin)
+      self@yarp.DeviceDriver(SwigRef.Null);
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;

--- a/matlab/autogenerated/+yarp/PolyDriver.m
+++ b/matlab/autogenerated/+yarp/PolyDriver.m
@@ -9,7 +9,7 @@ classdef PolyDriver < yarp.DeviceDriver
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(1069, varargin{:});
+        tmp = yarpMEX(1055, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
@@ -18,35 +18,35 @@ classdef PolyDriver < yarp.DeviceDriver
     %Usage: retval = open_str (txt)
     %
     %txt is of type std::string const &. txt is of type std::string const &. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1070, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1056, self, varargin{:});
     end
     function varargout = open(self,varargin)
     %Usage: retval = open (config)
     %
     %config is of type Searchable. config is of type Searchable. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1071, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1057, self, varargin{:});
     end
     function varargout = link(self,varargin)
     %Usage: retval = link (alt)
     %
     %alt is of type PolyDriver. alt is of type PolyDriver. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1072, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1058, self, varargin{:});
     end
     function varargout = take(self,varargin)
     %Usage: retval = take ()
     %
     %retval is of type DeviceDriver. 
-      [varargout{1:nargout}] = yarpMEX(1073, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1059, self, varargin{:});
     end
     function varargout = give(self,varargin)
     %Usage: retval = give (dd, own)
     %
     %dd is of type DeviceDriver. own is of type bool. dd is of type DeviceDriver. own is of type bool. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1074, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1060, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1075, self);
+        yarpMEX(1061, self);
         self.SwigClear();
       end
     end
@@ -54,175 +54,175 @@ classdef PolyDriver < yarp.DeviceDriver
     %Usage: retval = close ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1076, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1062, self, varargin{:});
     end
     function varargout = isValid(self,varargin)
     %Usage: retval = isValid ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1077, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1063, self, varargin{:});
     end
     function varargout = getOptions(self,varargin)
     %Usage: retval = getOptions ()
     %
     %retval is of type Bottle. 
-      [varargout{1:nargout}] = yarpMEX(1078, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1064, self, varargin{:});
     end
     function varargout = getComment(self,varargin)
     %Usage: retval = getComment (option)
     %
     %option is of type char const *. option is of type char const *. retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(1079, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1065, self, varargin{:});
     end
     function varargout = getDefaultValue(self,varargin)
     %Usage: retval = getDefaultValue (option)
     %
     %option is of type char const *. option is of type char const *. retval is of type Value. 
-      [varargout{1:nargout}] = yarpMEX(1080, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1066, self, varargin{:});
     end
     function varargout = getValue(self,varargin)
     %Usage: retval = getValue (option)
     %
     %option is of type char const *. option is of type char const *. retval is of type Value. 
-      [varargout{1:nargout}] = yarpMEX(1081, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1067, self, varargin{:});
     end
     function varargout = getImplementation(self,varargin)
     %Usage: retval = getImplementation ()
     %
     %retval is of type DeviceDriver. 
-      [varargout{1:nargout}] = yarpMEX(1082, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1068, self, varargin{:});
     end
     function varargout = viewFrameGrabberImage(self,varargin)
     %Usage: retval = viewFrameGrabberImage ()
     %
     %retval is of type IFrameGrabberImage. 
-      [varargout{1:nargout}] = yarpMEX(1083, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1069, self, varargin{:});
     end
     function varargout = viewIPositionControl(self,varargin)
     %Usage: retval = viewIPositionControl ()
     %
     %retval is of type IPositionControl. 
-      [varargout{1:nargout}] = yarpMEX(1084, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1070, self, varargin{:});
     end
     function varargout = viewIVelocityControl(self,varargin)
     %Usage: retval = viewIVelocityControl ()
     %
     %retval is of type IVelocityControl. 
-      [varargout{1:nargout}] = yarpMEX(1085, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1071, self, varargin{:});
     end
     function varargout = viewIEncoders(self,varargin)
     %Usage: retval = viewIEncoders ()
     %
     %retval is of type IEncoders. 
-      [varargout{1:nargout}] = yarpMEX(1086, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1072, self, varargin{:});
     end
     function varargout = viewIMotorEncoders(self,varargin)
     %Usage: retval = viewIMotorEncoders ()
     %
     %retval is of type IMotorEncoders. 
-      [varargout{1:nargout}] = yarpMEX(1087, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1073, self, varargin{:});
     end
     function varargout = viewIPidControl(self,varargin)
     %Usage: retval = viewIPidControl ()
     %
     %retval is of type IPidControl. 
-      [varargout{1:nargout}] = yarpMEX(1088, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1074, self, varargin{:});
     end
     function varargout = viewIAmplifierControl(self,varargin)
     %Usage: retval = viewIAmplifierControl ()
     %
     %retval is of type IAmplifierControl. 
-      [varargout{1:nargout}] = yarpMEX(1089, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1075, self, varargin{:});
     end
     function varargout = viewIControlLimits(self,varargin)
     %Usage: retval = viewIControlLimits ()
     %
     %retval is of type IControlLimits. 
-      [varargout{1:nargout}] = yarpMEX(1090, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1076, self, varargin{:});
     end
     function varargout = viewICartesianControl(self,varargin)
     %Usage: retval = viewICartesianControl ()
     %
     %retval is of type ICartesianControl. 
-      [varargout{1:nargout}] = yarpMEX(1091, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1077, self, varargin{:});
     end
     function varargout = viewIGazeControl(self,varargin)
     %Usage: retval = viewIGazeControl ()
     %
     %retval is of type IGazeControl. 
-      [varargout{1:nargout}] = yarpMEX(1092, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1078, self, varargin{:});
     end
     function varargout = viewIImpedanceControl(self,varargin)
     %Usage: retval = viewIImpedanceControl ()
     %
     %retval is of type IImpedanceControl. 
-      [varargout{1:nargout}] = yarpMEX(1093, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1079, self, varargin{:});
     end
     function varargout = viewITorqueControl(self,varargin)
     %Usage: retval = viewITorqueControl ()
     %
     %retval is of type ITorqueControl. 
-      [varargout{1:nargout}] = yarpMEX(1094, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1080, self, varargin{:});
     end
     function varargout = viewIControlMode(self,varargin)
     %Usage: retval = viewIControlMode ()
     %
     %retval is of type IControlMode. 
-      [varargout{1:nargout}] = yarpMEX(1095, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1081, self, varargin{:});
     end
     function varargout = viewIControlMode2(self,varargin)
     %Usage: retval = viewIControlMode2 ()
     %
     %retval is of type IControlMode. 
-      [varargout{1:nargout}] = yarpMEX(1096, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1082, self, varargin{:});
     end
     function varargout = viewIPWMControl(self,varargin)
     %Usage: retval = viewIPWMControl ()
     %
     %retval is of type IPWMControl. 
-      [varargout{1:nargout}] = yarpMEX(1097, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1083, self, varargin{:});
     end
     function varargout = viewICurrentControl(self,varargin)
     %Usage: retval = viewICurrentControl ()
     %
     %retval is of type ICurrentControl. 
-      [varargout{1:nargout}] = yarpMEX(1098, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1084, self, varargin{:});
     end
     function varargout = viewIAnalogSensor(self,varargin)
     %Usage: retval = viewIAnalogSensor ()
     %
     %retval is of type IAnalogSensor. 
-      [varargout{1:nargout}] = yarpMEX(1099, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1085, self, varargin{:});
     end
     function varargout = viewIFrameGrabberControls2(self,varargin)
     %Usage: retval = viewIFrameGrabberControls2 ()
     %
     %retval is of type IFrameGrabberControls. 
-      [varargout{1:nargout}] = yarpMEX(1100, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1086, self, varargin{:});
     end
     function varargout = viewIFrameGrabberControls(self,varargin)
     %Usage: retval = viewIFrameGrabberControls ()
     %
     %retval is of type IFrameGrabberControls. 
-      [varargout{1:nargout}] = yarpMEX(1101, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1087, self, varargin{:});
     end
     function varargout = viewIPositionDirect(self,varargin)
     %Usage: retval = viewIPositionDirect ()
     %
     %retval is of type IPositionDirect. 
-      [varargout{1:nargout}] = yarpMEX(1102, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1088, self, varargin{:});
     end
     function varargout = viewIRemoteVariables(self,varargin)
     %Usage: retval = viewIRemoteVariables ()
     %
     %retval is of type IRemoteVariables. 
-      [varargout{1:nargout}] = yarpMEX(1103, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1089, self, varargin{:});
     end
     function varargout = viewIAxisInfo(self,varargin)
     %Usage: retval = viewIAxisInfo ()
     %
     %retval is of type IAxisInfo. 
-      [varargout{1:nargout}] = yarpMEX(1104, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1090, self, varargin{:});
     end
   end
   methods(Static)

--- a/matlab/autogenerated/+yarp/Port.m
+++ b/matlab/autogenerated/+yarp/Port.m
@@ -1,11 +1,9 @@
-classdef Port < SwigRef
+classdef Port < yarp.UnbufferedContactable
     %Usage: Port ()
     %
   methods
-    function this = swig_this(self)
-      this = yarpMEX(3, self);
-    end
     function self = Port(varargin)
+      self@yarp.UnbufferedContactable(SwigRef.Null);
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;

--- a/matlab/autogenerated/+yarp/Port.m
+++ b/matlab/autogenerated/+yarp/Port.m
@@ -9,14 +9,14 @@ classdef Port < yarp.UnbufferedContactable
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(259, varargin{:});
+        tmp = yarpMEX(247, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(260, self);
+        yarpMEX(248, self);
         self.SwigClear();
       end
     end
@@ -24,241 +24,241 @@ classdef Port < yarp.UnbufferedContactable
     %Usage: retval = sharedOpen (port)
     %
     %port is of type Port. port is of type Port. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(261, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(249, self, varargin{:});
     end
     function varargout = openFake(self,varargin)
     %Usage: retval = openFake (name)
     %
     %name is of type std::string const &. name is of type std::string const &. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(262, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(250, self, varargin{:});
     end
     function varargout = addOutput(self,varargin)
     %Usage: retval = addOutput (contact)
     %
     %contact is of type Contact. contact is of type Contact. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(263, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(251, self, varargin{:});
     end
     function varargout = close(self,varargin)
     %Usage: close ()
     %
-      [varargout{1:nargout}] = yarpMEX(264, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(252, self, varargin{:});
     end
     function varargout = interrupt(self,varargin)
     %Usage: interrupt ()
     %
-      [varargout{1:nargout}] = yarpMEX(265, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(253, self, varargin{:});
     end
     function varargout = resume(self,varargin)
     %Usage: resume ()
     %
-      [varargout{1:nargout}] = yarpMEX(266, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(254, self, varargin{:});
     end
     function varargout = where(self,varargin)
     %Usage: retval = where ()
     %
     %retval is of type Contact. 
-      [varargout{1:nargout}] = yarpMEX(267, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(255, self, varargin{:});
     end
     function varargout = read(self,varargin)
     %Usage: retval = read (reader)
     %
     %reader is of type PortReader. reader is of type PortReader. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(268, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(256, self, varargin{:});
     end
     function varargout = replyAndDrop(self,varargin)
     %Usage: retval = replyAndDrop (writer)
     %
     %writer is of type PortWriter. writer is of type PortWriter. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(269, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(257, self, varargin{:});
     end
     function varargout = setReader(self,varargin)
     %Usage: setReader (reader)
     %
     %reader is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(270, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(258, self, varargin{:});
     end
     function varargout = setAdminReader(self,varargin)
     %Usage: setAdminReader (reader)
     %
     %reader is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(271, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(259, self, varargin{:});
     end
     function varargout = setReaderCreator(self,varargin)
     %Usage: setReaderCreator (creator)
     %
     %creator is of type PortReaderCreator &. 
-      [varargout{1:nargout}] = yarpMEX(272, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(260, self, varargin{:});
     end
     function varargout = enableBackgroundWrite(self,varargin)
     %Usage: enableBackgroundWrite (backgroundFlag)
     %
     %backgroundFlag is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(273, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(261, self, varargin{:});
     end
     function varargout = isWriting(self,varargin)
     %Usage: retval = isWriting ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(274, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(262, self, varargin{:});
     end
     function varargout = setEnvelope(self,varargin)
     %Usage: retval = setEnvelope (envelope)
     %
     %envelope is of type PortWriter. envelope is of type PortWriter. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(275, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(263, self, varargin{:});
     end
     function varargout = getEnvelope(self,varargin)
     %Usage: retval = getEnvelope (envelope)
     %
     %envelope is of type PortReader. envelope is of type PortReader. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(276, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(264, self, varargin{:});
     end
     function varargout = getInputCount(self,varargin)
     %Usage: retval = getInputCount ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(277, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(265, self, varargin{:});
     end
     function varargout = getOutputCount(self,varargin)
     %Usage: retval = getOutputCount ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(278, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(266, self, varargin{:});
     end
     function varargout = getReport(self,varargin)
     %Usage: getReport (reporter)
     %
     %reporter is of type PortReport. 
-      [varargout{1:nargout}] = yarpMEX(279, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(267, self, varargin{:});
     end
     function varargout = setReporter(self,varargin)
     %Usage: setReporter (reporter)
     %
     %reporter is of type PortReport. 
-      [varargout{1:nargout}] = yarpMEX(280, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(268, self, varargin{:});
     end
     function varargout = resetReporter(self,varargin)
     %Usage: resetReporter ()
     %
-      [varargout{1:nargout}] = yarpMEX(281, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(269, self, varargin{:});
     end
     function varargout = setAdminMode(self,varargin)
     %Usage: setAdminMode ()
     %
-      [varargout{1:nargout}] = yarpMEX(282, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(270, self, varargin{:});
     end
     function varargout = setInputMode(self,varargin)
     %Usage: setInputMode (expectInput)
     %
     %expectInput is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(283, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(271, self, varargin{:});
     end
     function varargout = setOutputMode(self,varargin)
     %Usage: setOutputMode (expectOutput)
     %
     %expectOutput is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(284, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(272, self, varargin{:});
     end
     function varargout = setRpcMode(self,varargin)
     %Usage: setRpcMode (expectRpc)
     %
     %expectRpc is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(285, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(273, self, varargin{:});
     end
     function varargout = setTimeout(self,varargin)
     %Usage: retval = setTimeout (timeout)
     %
     %timeout is of type float. timeout is of type float. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(286, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(274, self, varargin{:});
     end
     function varargout = setVerbosity(self,varargin)
     %Usage: setVerbosity (level)
     %
     %level is of type int. 
-      [varargout{1:nargout}] = yarpMEX(287, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(275, self, varargin{:});
     end
     function varargout = getVerbosity(self,varargin)
     %Usage: retval = getVerbosity ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(288, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(276, self, varargin{:});
     end
     function varargout = getType(self,varargin)
     %Usage: retval = getType ()
     %
-    %retval is of type Type. 
-      [varargout{1:nargout}] = yarpMEX(289, self, varargin{:});
+    %retval is of type yarp::os::Type. 
+      [varargout{1:nargout}] = yarpMEX(277, self, varargin{:});
     end
     function varargout = promiseType(self,varargin)
     %Usage: promiseType (typ)
     %
-    %typ is of type Type const &. 
-      [varargout{1:nargout}] = yarpMEX(290, self, varargin{:});
+    %typ is of type yarp::os::Type const &. 
+      [varargout{1:nargout}] = yarpMEX(278, self, varargin{:});
     end
     function varargout = acquireProperties(self,varargin)
     %Usage: retval = acquireProperties (readOnly)
     %
     %readOnly is of type bool. readOnly is of type bool. retval is of type Property. 
-      [varargout{1:nargout}] = yarpMEX(291, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(279, self, varargin{:});
     end
     function varargout = releaseProperties(self,varargin)
     %Usage: releaseProperties (prop)
     %
     %prop is of type Property. 
-      [varargout{1:nargout}] = yarpMEX(292, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(280, self, varargin{:});
     end
     function varargout = includeNodeInName(self,varargin)
     %Usage: includeNodeInName (flag)
     %
     %flag is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(293, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(281, self, varargin{:});
     end
     function varargout = isOpen(self,varargin)
     %Usage: retval = isOpen ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(294, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(282, self, varargin{:});
     end
     function varargout = setCallbackLock(self,varargin)
     %Usage: retval = setCallbackLock ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(295, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(283, self, varargin{:});
     end
     function varargout = removeCallbackLock(self,varargin)
     %Usage: retval = removeCallbackLock ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(296, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(284, self, varargin{:});
     end
     function varargout = lockCallback(self,varargin)
     %Usage: retval = lockCallback ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(297, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(285, self, varargin{:});
     end
     function varargout = tryLockCallback(self,varargin)
     %Usage: retval = tryLockCallback ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(298, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(286, self, varargin{:});
     end
     function varargout = unlockCallback(self,varargin)
     %Usage: unlockCallback ()
     %
-      [varargout{1:nargout}] = yarpMEX(299, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(287, self, varargin{:});
     end
     function varargout = write(self,varargin)
     %Usage: retval = write (data1, data2)
     %
     %data1 is of type Bottle. data2 is of type ImageFloat. data1 is of type Bottle. data2 is of type ImageFloat. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(300, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(288, self, varargin{:});
     end
     function varargout = reply(self,varargin)
     %Usage: retval = reply (data)
     %
     %data is of type Bottle. data is of type Bottle. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(301, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(289, self, varargin{:});
     end
   end
   methods(Static)

--- a/matlab/autogenerated/+yarp/PortReader.m
+++ b/matlab/autogenerated/+yarp/PortReader.m
@@ -7,7 +7,7 @@ classdef PortReader < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(115, self);
+        yarpMEX(103, self);
         self.SwigClear();
       end
     end
@@ -15,13 +15,13 @@ classdef PortReader < SwigRef
     %Usage: retval = read (reader)
     %
     %reader is of type ConnectionReader. reader is of type ConnectionReader. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(116, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(104, self, varargin{:});
     end
     function varargout = getReadType(self,varargin)
     %Usage: retval = getReadType ()
     %
-    %retval is of type Type. 
-      [varargout{1:nargout}] = yarpMEX(117, self, varargin{:});
+    %retval is of type yarp::os::Type. 
+      [varargout{1:nargout}] = yarpMEX(105, self, varargin{:});
     end
     function self = PortReader(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/PortReaderCreator.m
+++ b/matlab/autogenerated/+yarp/PortReaderCreator.m
@@ -7,7 +7,7 @@ classdef PortReaderCreator < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(398, self);
+        yarpMEX(386, self);
         self.SwigClear();
       end
     end
@@ -15,7 +15,7 @@ classdef PortReaderCreator < SwigRef
     %Usage: retval = create ()
     %
     %retval is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(399, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(387, self, varargin{:});
     end
     function self = PortReaderCreator(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/PortWriter.m
+++ b/matlab/autogenerated/+yarp/PortWriter.m
@@ -7,7 +7,7 @@ classdef PortWriter < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(118, self);
+        yarpMEX(106, self);
         self.SwigClear();
       end
     end
@@ -15,23 +15,23 @@ classdef PortWriter < SwigRef
     %Usage: retval = write (writer)
     %
     %writer is of type ConnectionWriter. writer is of type ConnectionWriter. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(119, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(107, self, varargin{:});
     end
     function varargout = onCompletion(self,varargin)
     %Usage: onCompletion ()
     %
-      [varargout{1:nargout}] = yarpMEX(120, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(108, self, varargin{:});
     end
     function varargout = onCommencement(self,varargin)
     %Usage: onCommencement ()
     %
-      [varargout{1:nargout}] = yarpMEX(121, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(109, self, varargin{:});
     end
     function varargout = getWriteType(self,varargin)
     %Usage: retval = getWriteType ()
     %
-    %retval is of type Type. 
-      [varargout{1:nargout}] = yarpMEX(122, self, varargin{:});
+    %retval is of type yarp::os::Type. 
+      [varargout{1:nargout}] = yarpMEX(110, self, varargin{:});
     end
     function self = PortWriter(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/PortWriterBufferBase.m
+++ b/matlab/autogenerated/+yarp/PortWriterBufferBase.m
@@ -7,7 +7,7 @@ classdef PortWriterBufferBase < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(466, self);
+        yarpMEX(454, self);
         self.SwigClear();
       end
     end
@@ -15,47 +15,47 @@ classdef PortWriterBufferBase < SwigRef
     %Usage: retval = create (man, tracker)
     %
     %man is of type PortWriterBufferManager. tracker is of type void *. man is of type PortWriterBufferManager. tracker is of type void *. retval is of type PortWriterWrapper. 
-      [varargout{1:nargout}] = yarpMEX(467, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(455, self, varargin{:});
     end
     function varargout = getContent(self,varargin)
     %Usage: retval = getContent ()
     %
-    %retval is of type void *. 
-      [varargout{1:nargout}] = yarpMEX(468, self, varargin{:});
+    %retval is of type void const *. 
+      [varargout{1:nargout}] = yarpMEX(456, self, varargin{:});
     end
     function varargout = releaseContent(self,varargin)
     %Usage: retval = releaseContent ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(469, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(457, self, varargin{:});
     end
     function varargout = getCount(self,varargin)
     %Usage: retval = getCount ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(470, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(458, self, varargin{:});
     end
     function varargout = attach(self,varargin)
     %Usage: attach (port)
     %
     %port is of type Port. 
-      [varargout{1:nargout}] = yarpMEX(471, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(459, self, varargin{:});
     end
     function varargout = detach(self,varargin)
     %Usage: detach ()
     %
-      [varargout{1:nargout}] = yarpMEX(472, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(460, self, varargin{:});
     end
     function varargout = write(self,varargin)
     %Usage: write (strict)
     %
     %strict is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(473, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(461, self, varargin{:});
     end
     function varargout = waitForWrite(self,varargin)
     %Usage: waitForWrite ()
     %
-      [varargout{1:nargout}] = yarpMEX(474, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(462, self, varargin{:});
     end
     function self = PortWriterBufferBase(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/PortWriterBufferManager.m
+++ b/matlab/autogenerated/+yarp/PortWriterBufferManager.m
@@ -7,7 +7,7 @@ classdef PortWriterBufferManager < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(462, self);
+        yarpMEX(450, self);
         self.SwigClear();
       end
     end
@@ -15,7 +15,7 @@ classdef PortWriterBufferManager < SwigRef
     %Usage: onCompletion (tracker)
     %
     %tracker is of type void *. 
-      [varargout{1:nargout}] = yarpMEX(463, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(451, self, varargin{:});
     end
     function self = PortWriterBufferManager(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/PortWriterWrapper.m
+++ b/matlab/autogenerated/+yarp/PortWriterWrapper.m
@@ -6,11 +6,11 @@ classdef PortWriterWrapper < yarp.PortWriter
     %Usage: retval = getInternal ()
     %
     %retval is of type PortWriter. 
-      [varargout{1:nargout}] = yarpMEX(464, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(452, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(465, self);
+        yarpMEX(453, self);
         self.SwigClear();
       end
     end

--- a/matlab/autogenerated/+yarp/PortWriterWrapper.m
+++ b/matlab/autogenerated/+yarp/PortWriterWrapper.m
@@ -1,10 +1,7 @@
-classdef PortWriterWrapper < SwigRef
+classdef PortWriterWrapper < yarp.PortWriter
     %Usage: PortWriterWrapper ()
     %
   methods
-    function this = swig_this(self)
-      this = yarpMEX(3, self);
-    end
     function varargout = getInternal(self,varargin)
     %Usage: retval = getInternal ()
     %
@@ -18,6 +15,7 @@ classdef PortWriterWrapper < SwigRef
       end
     end
     function self = PortWriterWrapper(varargin)
+      self@yarp.PortWriter(SwigRef.Null);
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;

--- a/matlab/autogenerated/+yarp/Portable.m
+++ b/matlab/autogenerated/+yarp/Portable.m
@@ -9,23 +9,23 @@ classdef Portable < yarp.PortReader & yarp.PortWriter
     %Usage: retval = read (reader)
     %
     %reader is of type ConnectionReader. reader is of type ConnectionReader. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(123, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(111, self, varargin{:});
     end
     function varargout = write(self,varargin)
     %Usage: retval = write (writer)
     %
     %writer is of type ConnectionWriter. writer is of type ConnectionWriter. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(124, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(112, self, varargin{:});
     end
     function varargout = getType(self,varargin)
     %Usage: retval = getType ()
     %
-    %retval is of type Type. 
-      [varargout{1:nargout}] = yarpMEX(125, self, varargin{:});
+    %retval is of type yarp::os::Type. 
+      [varargout{1:nargout}] = yarpMEX(113, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(127, self);
+        yarpMEX(115, self);
         self.SwigClear();
       end
     end
@@ -46,7 +46,7 @@ classdef Portable < yarp.PortReader & yarp.PortWriter
     %Usage: retval = copyPortable (writer, reader)
     %
     %writer is of type PortWriter. reader is of type PortReader. writer is of type PortWriter. reader is of type PortReader. retval is of type bool. 
-     [varargout{1:nargout}] = yarpMEX(126, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(114, varargin{:});
     end
   end
 end

--- a/matlab/autogenerated/+yarp/Portable.m
+++ b/matlab/autogenerated/+yarp/Portable.m
@@ -1,4 +1,4 @@
-classdef Portable < SwigRef
+classdef Portable < yarp.PortReader & yarp.PortWriter
     %Usage: Portable ()
     %
   methods
@@ -30,6 +30,8 @@ classdef Portable < SwigRef
       end
     end
     function self = Portable(varargin)
+      self@yarp.PortReader(SwigRef.Null);
+      self@yarp.PortWriter(SwigRef.Null);
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;

--- a/matlab/autogenerated/+yarp/PortablePairBase.m
+++ b/matlab/autogenerated/+yarp/PortablePairBase.m
@@ -4,7 +4,7 @@ classdef PortablePairBase < yarp.Portable
   methods
     function delete(self)
       if self.swigPtr
-        yarpMEX(397, self);
+        yarpMEX(385, self);
         self.SwigClear();
       end
     end
@@ -24,13 +24,13 @@ classdef PortablePairBase < yarp.Portable
     %Usage: retval = readPair (connection, head, body)
     %
     %connection is of type ConnectionReader. head is of type Portable. body is of type Portable. connection is of type ConnectionReader. head is of type Portable. body is of type Portable. retval is of type bool. 
-     [varargout{1:nargout}] = yarpMEX(395, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(383, varargin{:});
     end
     function varargout = writePair(varargin)
     %Usage: retval = writePair (connection, head, body)
     %
     %connection is of type ConnectionWriter. head is of type Portable. body is of type Portable. connection is of type ConnectionWriter. head is of type Portable. body is of type Portable. retval is of type bool. 
-     [varargout{1:nargout}] = yarpMEX(396, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(384, varargin{:});
     end
   end
 end

--- a/matlab/autogenerated/+yarp/PortablePairBase.m
+++ b/matlab/autogenerated/+yarp/PortablePairBase.m
@@ -1,10 +1,7 @@
-classdef PortablePairBase < SwigRef
+classdef PortablePairBase < yarp.Portable
     %Usage: PortablePairBase ()
     %
   methods
-    function this = swig_this(self)
-      this = yarpMEX(3, self);
-    end
     function delete(self)
       if self.swigPtr
         yarpMEX(397, self);
@@ -12,6 +9,7 @@ classdef PortablePairBase < SwigRef
       end
     end
     function self = PortablePairBase(varargin)
+      self@yarp.Portable(SwigRef.Null);
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;

--- a/matlab/autogenerated/+yarp/Property.m
+++ b/matlab/autogenerated/+yarp/Property.m
@@ -1,4 +1,4 @@
-classdef Property < SwigRef
+classdef Property < yarp.Searchable & yarp.Portable
     %Usage: Property ()
     %
   methods
@@ -6,6 +6,8 @@ classdef Property < SwigRef
       this = yarpMEX(3, self);
     end
     function self = Property(varargin)
+      self@yarp.Searchable(SwigRef.Null);
+      self@yarp.Portable(SwigRef.Null);
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;

--- a/matlab/autogenerated/+yarp/Property.m
+++ b/matlab/autogenerated/+yarp/Property.m
@@ -13,14 +13,14 @@ classdef Property < yarp.Searchable & yarp.Portable
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(400, varargin{:});
+        tmp = yarpMEX(388, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(401, self);
+        yarpMEX(389, self);
         self.SwigClear();
       end
     end
@@ -28,108 +28,108 @@ classdef Property < yarp.Searchable & yarp.Portable
     %Usage: retval = check (key)
     %
     %key is of type std::string const &. key is of type std::string const &. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(402, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(390, self, varargin{:});
     end
     function varargout = put(self,varargin)
     %Usage: put (key, value)
     %
     %key is of type std::string const &. value is of type double. 
-      [varargout{1:nargout}] = yarpMEX(403, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(391, self, varargin{:});
     end
     function varargout = addGroup(self,varargin)
     %Usage: retval = addGroup (key)
     %
     %key is of type std::string const &. key is of type std::string const &. retval is of type Property. 
-      [varargout{1:nargout}] = yarpMEX(404, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(392, self, varargin{:});
     end
     function varargout = unput(self,varargin)
     %Usage: unput (key)
     %
     %key is of type std::string const &. 
-      [varargout{1:nargout}] = yarpMEX(405, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(393, self, varargin{:});
     end
     function varargout = find(self,varargin)
     %Usage: retval = find (key)
     %
     %key is of type std::string const &. key is of type std::string const &. retval is of type Value. 
-      [varargout{1:nargout}] = yarpMEX(406, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(394, self, varargin{:});
     end
     function varargout = findGroup(self,varargin)
     %Usage: retval = findGroup (key)
     %
     %key is of type std::string const &. key is of type std::string const &. retval is of type Bottle. 
-      [varargout{1:nargout}] = yarpMEX(407, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(395, self, varargin{:});
     end
     function varargout = clear(self,varargin)
     %Usage: clear ()
     %
-      [varargout{1:nargout}] = yarpMEX(408, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(396, self, varargin{:});
     end
     function varargout = fromString(self,varargin)
     %Usage: fromString (txt)
     %
     %txt is of type std::string const &. 
-      [varargout{1:nargout}] = yarpMEX(409, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(397, self, varargin{:});
     end
     function varargout = fromCommand(self,varargin)
     %Usage: fromCommand (argc, argv)
     %
     %argc is of type int. argv is of type char const *[]. 
-      [varargout{1:nargout}] = yarpMEX(410, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(398, self, varargin{:});
     end
     function varargout = fromArguments(self,varargin)
     %Usage: fromArguments (arguments)
     %
     %arguments is of type char const *. 
-      [varargout{1:nargout}] = yarpMEX(411, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(399, self, varargin{:});
     end
     function varargout = fromConfigFile(self,varargin)
     %Usage: retval = fromConfigFile (fname, env)
     %
     %fname is of type std::string const &. env is of type Searchable. fname is of type std::string const &. env is of type Searchable. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(412, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(400, self, varargin{:});
     end
     function varargout = fromConfigDir(self,varargin)
     %Usage: retval = fromConfigDir (dirname)
     %
     %dirname is of type std::string const &. dirname is of type std::string const &. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(413, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(401, self, varargin{:});
     end
     function varargout = fromConfig(self,varargin)
     %Usage: fromConfig (txt, env)
     %
     %txt is of type char const *. env is of type Searchable. 
-      [varargout{1:nargout}] = yarpMEX(414, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(402, self, varargin{:});
     end
     function varargout = fromQuery(self,varargin)
     %Usage: fromQuery (url)
     %
     %url is of type char const *. 
-      [varargout{1:nargout}] = yarpMEX(415, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(403, self, varargin{:});
     end
     function varargout = toString_c(self,varargin)
     %Usage: retval = toString_c ()
     %
     %retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(416, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(404, self, varargin{:});
     end
     function varargout = read(self,varargin)
     %Usage: retval = read (reader)
     %
     %reader is of type ConnectionReader. reader is of type ConnectionReader. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(417, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(405, self, varargin{:});
     end
     function varargout = write(self,varargin)
     %Usage: retval = write (writer)
     %
     %writer is of type ConnectionWriter. writer is of type ConnectionWriter. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(418, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(406, self, varargin{:});
     end
     function varargout = toString(self,varargin)
     %Usage: retval = toString ()
     %
     %retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(419, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(407, self, varargin{:});
     end
   end
   methods(Static)

--- a/matlab/autogenerated/+yarp/PropertyCallback.m
+++ b/matlab/autogenerated/+yarp/PropertyCallback.m
@@ -7,7 +7,7 @@ classdef PropertyCallback < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(741, self);
+        yarpMEX(727, self);
         self.SwigClear();
       end
     end
@@ -15,7 +15,7 @@ classdef PropertyCallback < SwigRef
     %Usage: onRead (datum, reader)
     %
     %datum is of type Property. reader is of type TypedReaderProperty. 
-      [varargout{1:nargout}] = yarpMEX(742, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(728, self, varargin{:});
     end
     function self = PropertyCallback(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -23,7 +23,7 @@ classdef PropertyCallback < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(743, varargin{:});
+        tmp = yarpMEX(729, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end

--- a/matlab/autogenerated/+yarp/QosStyle.m
+++ b/matlab/autogenerated/+yarp/QosStyle.m
@@ -11,7 +11,7 @@ classdef QosStyle < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(700, varargin{:});
+        tmp = yarpMEX(686, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
@@ -20,71 +20,71 @@ classdef QosStyle < SwigRef
     %Usage: setPacketPriorityByDscp (dscp)
     %
     %dscp is of type yarp::os::QosStyle::PacketPriorityDSCP. 
-      [varargout{1:nargout}] = yarpMEX(701, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(687, self, varargin{:});
     end
     function varargout = setPacketPriorityByLevel(self,varargin)
     %Usage: setPacketPriorityByLevel (level)
     %
     %level is of type yarp::os::QosStyle::PacketPriorityLevel. 
-      [varargout{1:nargout}] = yarpMEX(702, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(688, self, varargin{:});
     end
     function varargout = setPacketPrioritybyTOS(self,varargin)
     %Usage: setPacketPrioritybyTOS (tos)
     %
     %tos is of type int. 
-      [varargout{1:nargout}] = yarpMEX(703, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(689, self, varargin{:});
     end
     function varargout = setPacketPriority(self,varargin)
     %Usage: retval = setPacketPriority (priority)
     %
     %priority is of type std::string const &. priority is of type std::string const &. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(704, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(690, self, varargin{:});
     end
     function varargout = setThreadPriority(self,varargin)
     %Usage: setThreadPriority (priority)
     %
     %priority is of type int. 
-      [varargout{1:nargout}] = yarpMEX(705, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(691, self, varargin{:});
     end
     function varargout = setThreadPolicy(self,varargin)
     %Usage: setThreadPolicy (policy)
     %
     %policy is of type int. 
-      [varargout{1:nargout}] = yarpMEX(706, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(692, self, varargin{:});
     end
     function varargout = getPacketPriorityAsTOS(self,varargin)
     %Usage: retval = getPacketPriorityAsTOS ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(707, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(693, self, varargin{:});
     end
     function varargout = getPacketPriorityAsDSCP(self,varargin)
     %Usage: retval = getPacketPriorityAsDSCP ()
     %
     %retval is of type yarp::os::QosStyle::PacketPriorityDSCP. 
-      [varargout{1:nargout}] = yarpMEX(708, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(694, self, varargin{:});
     end
     function varargout = getPacketPriorityAsLevel(self,varargin)
     %Usage: retval = getPacketPriorityAsLevel ()
     %
     %retval is of type yarp::os::QosStyle::PacketPriorityLevel. 
-      [varargout{1:nargout}] = yarpMEX(709, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(695, self, varargin{:});
     end
     function varargout = getThreadPriority(self,varargin)
     %Usage: retval = getThreadPriority ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(710, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(696, self, varargin{:});
     end
     function varargout = getThreadPolicy(self,varargin)
     %Usage: retval = getThreadPolicy ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(711, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(697, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(714, self);
+        yarpMEX(700, self);
         self.SwigClear();
       end
     end
@@ -304,13 +304,13 @@ classdef QosStyle < SwigRef
     %Usage: retval = getDSCPByVocab (vocab)
     %
     %vocab is of type int. vocab is of type int. retval is of type yarp::os::QosStyle::PacketPriorityDSCP. 
-     [varargout{1:nargout}] = yarpMEX(712, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(698, varargin{:});
     end
     function varargout = getLevelByVocab(varargin)
     %Usage: retval = getLevelByVocab (vocab)
     %
     %vocab is of type int. vocab is of type int. retval is of type yarp::os::QosStyle::PacketPriorityLevel. 
-     [varargout{1:nargout}] = yarpMEX(713, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(699, varargin{:});
     end
   end
 end

--- a/matlab/autogenerated/+yarp/RFModule.m
+++ b/matlab/autogenerated/+yarp/RFModule.m
@@ -7,7 +7,7 @@ classdef RFModule < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(571, self);
+        yarpMEX(559, self);
         self.SwigClear();
       end
     end
@@ -15,108 +15,108 @@ classdef RFModule < SwigRef
     %Usage: retval = getPeriod ()
     %
     %retval is of type double. 
-      [varargout{1:nargout}] = yarpMEX(572, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(560, self, varargin{:});
     end
     function varargout = updateModule(self,varargin)
     %Usage: retval = updateModule ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(573, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(561, self, varargin{:});
     end
     function varargout = runModule(self,varargin)
     %Usage: retval = runModule (rf)
     %
     %rf is of type ResourceFinder. rf is of type ResourceFinder. retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(574, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(562, self, varargin{:});
     end
     function varargout = runModuleThreaded(self,varargin)
     %Usage: retval = runModuleThreaded (rf)
     %
     %rf is of type ResourceFinder. rf is of type ResourceFinder. retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(575, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(563, self, varargin{:});
     end
     function varargout = configure(self,varargin)
     %Usage: retval = configure (rf)
     %
     %rf is of type ResourceFinder. rf is of type ResourceFinder. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(576, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(564, self, varargin{:});
     end
     function varargout = respond(self,varargin)
     %Usage: retval = respond (command, reply)
     %
     %command is of type Bottle. reply is of type Bottle. command is of type Bottle. reply is of type Bottle. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(577, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(565, self, varargin{:});
     end
     function varargout = attach(self,varargin)
     %Usage: retval = attach (source)
     %
     %source is of type Port. source is of type Port. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(578, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(566, self, varargin{:});
     end
     function varargout = attach_rpc_server(self,varargin)
     %Usage: retval = attach_rpc_server (source)
     %
     %source is of type RpcServer. source is of type RpcServer. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(579, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(567, self, varargin{:});
     end
     function varargout = attachTerminal(self,varargin)
     %Usage: retval = attachTerminal ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(580, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(568, self, varargin{:});
     end
     function varargout = detachTerminal(self,varargin)
     %Usage: retval = detachTerminal ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(581, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(569, self, varargin{:});
     end
     function varargout = interruptModule(self,varargin)
     %Usage: retval = interruptModule ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(582, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(570, self, varargin{:});
     end
     function varargout = close(self,varargin)
     %Usage: retval = close ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(583, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(571, self, varargin{:});
     end
     function varargout = stopModule(self,varargin)
     %Usage: stopModule ()
     %
-      [varargout{1:nargout}] = yarpMEX(584, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(572, self, varargin{:});
     end
     function varargout = isStopping(self,varargin)
     %Usage: retval = isStopping ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(585, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(573, self, varargin{:});
     end
     function varargout = joinModule(self,varargin)
     %Usage: retval = joinModule ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(586, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(574, self, varargin{:});
     end
     function varargout = getName(self,varargin)
     %Usage: retval = getName ()
     %
     %retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(587, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(575, self, varargin{:});
     end
     function varargout = setName(self,varargin)
     %Usage: setName (name)
     %
     %name is of type char const *. 
-      [varargout{1:nargout}] = yarpMEX(588, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(576, self, varargin{:});
     end
     function varargout = safeRespond(self,varargin)
     %Usage: retval = safeRespond (command, reply)
     %
     %command is of type Bottle. reply is of type Bottle. command is of type Bottle. reply is of type Bottle. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(589, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(577, self, varargin{:});
     end
     function self = RFModule(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/Random.m
+++ b/matlab/autogenerated/+yarp/Random.m
@@ -11,14 +11,14 @@ classdef Random < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(478, varargin{:});
+        tmp = yarpMEX(466, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(479, self);
+        yarpMEX(467, self);
         self.SwigClear();
       end
     end
@@ -28,19 +28,19 @@ classdef Random < SwigRef
     %Usage: seed_c (seed)
     %
     %seed is of type int. 
-     [varargout{1:nargout}] = yarpMEX(475, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(463, varargin{:});
     end
     function varargout = normal(varargin)
     %Usage: retval = normal ()
     %
     %retval is of type double. 
-     [varargout{1:nargout}] = yarpMEX(476, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(464, varargin{:});
     end
     function varargout = uniform(varargin)
     %Usage: retval = uniform (min, max)
     %
     %min is of type int. max is of type int. min is of type int. max is of type int. retval is of type int. 
-     [varargout{1:nargout}] = yarpMEX(477, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(465, varargin{:});
     end
   end
 end

--- a/matlab/autogenerated/+yarp/RateThread.m
+++ b/matlab/autogenerated/+yarp/RateThread.m
@@ -7,7 +7,7 @@ classdef RateThread < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(525, self);
+        yarpMEX(513, self);
         self.SwigClear();
       end
     end
@@ -15,98 +15,98 @@ classdef RateThread < SwigRef
     %Usage: retval = start ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(526, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(514, self, varargin{:});
     end
     function varargout = step(self,varargin)
     %Usage: retval = step ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(527, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(515, self, varargin{:});
     end
     function varargout = stop(self,varargin)
     %Usage: stop ()
     %
-      [varargout{1:nargout}] = yarpMEX(528, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(516, self, varargin{:});
     end
     function varargout = askToStop(self,varargin)
     %Usage: askToStop ()
     %
-      [varargout{1:nargout}] = yarpMEX(529, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(517, self, varargin{:});
     end
     function varargout = isRunning(self,varargin)
     %Usage: retval = isRunning ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(530, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(518, self, varargin{:});
     end
     function varargout = isSuspended(self,varargin)
     %Usage: retval = isSuspended ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(531, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(519, self, varargin{:});
     end
     function varargout = setRate(self,varargin)
     %Usage: retval = setRate (period)
     %
     %period is of type int. period is of type int. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(532, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(520, self, varargin{:});
     end
     function varargout = getRate(self,varargin)
     %Usage: retval = getRate ()
     %
     %retval is of type double. 
-      [varargout{1:nargout}] = yarpMEX(533, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(521, self, varargin{:});
     end
     function varargout = suspend(self,varargin)
     %Usage: suspend ()
     %
-      [varargout{1:nargout}] = yarpMEX(534, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(522, self, varargin{:});
     end
     function varargout = resume(self,varargin)
     %Usage: resume ()
     %
-      [varargout{1:nargout}] = yarpMEX(535, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(523, self, varargin{:});
     end
     function varargout = resetStat(self,varargin)
     %Usage: resetStat ()
     %
-      [varargout{1:nargout}] = yarpMEX(536, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(524, self, varargin{:});
     end
     function varargout = getEstPeriod(self,varargin)
     %Usage: getEstPeriod (av, std)
     %
     %av is of type double &. std is of type double &. 
-      [varargout{1:nargout}] = yarpMEX(537, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(525, self, varargin{:});
     end
     function varargout = getIterations(self,varargin)
     %Usage: retval = getIterations ()
     %
     %retval is of type unsigned int. 
-      [varargout{1:nargout}] = yarpMEX(538, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(526, self, varargin{:});
     end
     function varargout = getEstUsed(self,varargin)
     %Usage: getEstUsed (av, std)
     %
     %av is of type double &. std is of type double &. 
-      [varargout{1:nargout}] = yarpMEX(539, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(527, self, varargin{:});
     end
     function varargout = setPriority(self,varargin)
     %Usage: retval = setPriority (priority)
     %
     %priority is of type int. priority is of type int. retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(540, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(528, self, varargin{:});
     end
     function varargout = getPriority(self,varargin)
     %Usage: retval = getPriority ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(541, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(529, self, varargin{:});
     end
     function varargout = getPolicy(self,varargin)
     %Usage: retval = getPolicy ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(542, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(530, self, varargin{:});
     end
     function self = RateThread(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/RateThreadWrapper.m
+++ b/matlab/autogenerated/+yarp/RateThreadWrapper.m
@@ -1,11 +1,9 @@
-classdef RateThreadWrapper < SwigRef
+classdef RateThreadWrapper < yarp.PeriodicThread
     %Usage: RateThreadWrapper ()
     %
   methods
-    function this = swig_this(self)
-      this = yarpMEX(3, self);
-    end
     function self = RateThreadWrapper(varargin)
+      self@yarp.PeriodicThread(SwigRef.Null);
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;

--- a/matlab/autogenerated/+yarp/RateThreadWrapper.m
+++ b/matlab/autogenerated/+yarp/RateThreadWrapper.m
@@ -9,76 +9,76 @@ classdef RateThreadWrapper < yarp.PeriodicThread
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(545, varargin{:});
+        tmp = yarpMEX(533, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(546, self);
+        yarpMEX(534, self);
         self.SwigClear();
       end
     end
     function varargout = detach(self,varargin)
     %Usage: detach ()
     %
-      [varargout{1:nargout}] = yarpMEX(547, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(535, self, varargin{:});
     end
     function varargout = attach(self,varargin)
     %Usage: retval = attach (helper)
     %
     %helper is of type Runnable *. helper is of type Runnable *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(548, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(536, self, varargin{:});
     end
     function varargout = open(self,varargin)
     %Usage: retval = open ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(549, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(537, self, varargin{:});
     end
     function varargout = close(self,varargin)
     %Usage: close ()
     %
-      [varargout{1:nargout}] = yarpMEX(550, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(538, self, varargin{:});
     end
     function varargout = stop(self,varargin)
     %Usage: stop ()
     %
-      [varargout{1:nargout}] = yarpMEX(551, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(539, self, varargin{:});
     end
     function varargout = run(self,varargin)
     %Usage: run ()
     %
-      [varargout{1:nargout}] = yarpMEX(552, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(540, self, varargin{:});
     end
     function varargout = threadInit(self,varargin)
     %Usage: retval = threadInit ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(553, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(541, self, varargin{:});
     end
     function varargout = threadRelease(self,varargin)
     %Usage: threadRelease ()
     %
-      [varargout{1:nargout}] = yarpMEX(554, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(542, self, varargin{:});
     end
     function varargout = afterStart(self,varargin)
     %Usage: afterStart (success)
     %
     %success is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(555, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(543, self, varargin{:});
     end
     function varargout = beforeStart(self,varargin)
     %Usage: beforeStart ()
     %
-      [varargout{1:nargout}] = yarpMEX(556, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(544, self, varargin{:});
     end
     function varargout = getAttachment(self,varargin)
     %Usage: retval = getAttachment ()
     %
     %retval is of type Runnable *. 
-      [varargout{1:nargout}] = yarpMEX(557, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(545, self, varargin{:});
     end
   end
   methods(Static)

--- a/matlab/autogenerated/+yarp/ResourceFinder.m
+++ b/matlab/autogenerated/+yarp/ResourceFinder.m
@@ -9,14 +9,14 @@ classdef ResourceFinder < yarp.Searchable
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(623, varargin{:});
+        tmp = yarpMEX(611, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(624, self);
+        yarpMEX(612, self);
         self.SwigClear();
       end
     end
@@ -24,139 +24,133 @@ classdef ResourceFinder < yarp.Searchable
     %Usage: retval = setVerbose ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(625, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(613, self, varargin{:});
     end
     function varargout = setQuiet(self,varargin)
     %Usage: retval = setQuiet ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(626, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(614, self, varargin{:});
     end
     function varargout = configure(self,varargin)
     %Usage: retval = configure (argc, argv)
     %
     %argc is of type int. argv is of type char *[]. argc is of type int. argv is of type char *[]. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(627, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(615, self, varargin{:});
     end
     function varargout = setDefaultContext(self,varargin)
     %Usage: retval = setDefaultContext (contextName)
     %
     %contextName is of type std::string const &. contextName is of type std::string const &. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(628, self, varargin{:});
-    end
-    function varargout = setContext(self,varargin)
-    %Usage: retval = setContext (contextName)
-    %
-    %contextName is of type char const *. contextName is of type char const *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(629, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(616, self, varargin{:});
     end
     function varargout = setDefault(self,varargin)
     %Usage: retval = setDefault (key, val)
     %
     %key is of type char const *. val is of type Value. key is of type char const *. val is of type Value. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(630, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(617, self, varargin{:});
     end
     function varargout = setDefaultConfigFile(self,varargin)
     %Usage: retval = setDefaultConfigFile (fname)
     %
     %fname is of type char const *. fname is of type char const *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(631, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(618, self, varargin{:});
     end
     function varargout = getContext(self,varargin)
     %Usage: retval = getContext ()
     %
     %retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(632, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(619, self, varargin{:});
     end
     function varargout = getContexts(self,varargin)
     %Usage: retval = getContexts ()
     %
     %retval is of type Bottle. 
-      [varargout{1:nargout}] = yarpMEX(633, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(620, self, varargin{:});
     end
     function varargout = find(self,varargin)
     %Usage: retval = find (key)
     %
     %key is of type std::string const &. key is of type std::string const &. retval is of type Value. 
-      [varargout{1:nargout}] = yarpMEX(634, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(621, self, varargin{:});
     end
     function varargout = isNull(self,varargin)
     %Usage: retval = isNull ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(635, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(622, self, varargin{:});
     end
     function varargout = toString_c(self,varargin)
     %Usage: retval = toString_c ()
     %
     %retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(636, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(623, self, varargin{:});
     end
     function varargout = findNestedResourceFinder(self,varargin)
     %Usage: retval = findNestedResourceFinder (key)
     %
     %key is of type char const *. key is of type char const *. retval is of type ResourceFinder. 
-      [varargout{1:nargout}] = yarpMEX(637, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(624, self, varargin{:});
     end
     function varargout = isConfigured(self,varargin)
     %Usage: retval = isConfigured ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(638, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(625, self, varargin{:});
     end
     function varargout = check(self,varargin)
     %Usage: retval = check (key, fallback)
     %
     %key is of type std::string const &. fallback is of type Value. key is of type std::string const &. fallback is of type Value. retval is of type Value. 
-      [varargout{1:nargout}] = yarpMEX(640, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(627, self, varargin{:});
     end
     function varargout = findGroup(self,varargin)
     %Usage: retval = findGroup (key, comment)
     %
     %key is of type std::string const &. comment is of type std::string const &. key is of type std::string const &. comment is of type std::string const &. retval is of type Bottle. 
-      [varargout{1:nargout}] = yarpMEX(641, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(628, self, varargin{:});
     end
     function varargout = getHomeContextPath(self,varargin)
     %Usage: retval = getHomeContextPath ()
     %
     %retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(646, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(633, self, varargin{:});
     end
     function varargout = getHomeRobotPath(self,varargin)
     %Usage: retval = getHomeRobotPath ()
     %
     %retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(647, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(634, self, varargin{:});
     end
     function varargout = findPaths(self,varargin)
     %Usage: retval = findPaths (name, options)
     %
     %name is of type std::string const &. options is of type ResourceFinderOptions const &. name is of type std::string const &. options is of type ResourceFinderOptions const &. retval is of type Bottle. 
-      [varargout{1:nargout}] = yarpMEX(650, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(637, self, varargin{:});
     end
     function varargout = findPath(self,varargin)
     %Usage: retval = findPath (name, options)
     %
     %name is of type std::string const &. options is of type ResourceFinderOptions const &. name is of type std::string const &. options is of type ResourceFinderOptions const &. retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(651, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(638, self, varargin{:});
     end
     function varargout = findFile(self,varargin)
     %Usage: retval = findFile (name, options)
     %
     %name is of type std::string const &. options is of type ResourceFinderOptions const &. name is of type std::string const &. options is of type ResourceFinderOptions const &. retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(652, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(639, self, varargin{:});
     end
     function varargout = findFileByName(self,varargin)
     %Usage: retval = findFileByName (name, options)
     %
     %name is of type std::string const &. options is of type ResourceFinderOptions const &. name is of type std::string const &. options is of type ResourceFinderOptions const &. retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(653, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(640, self, varargin{:});
     end
     function varargout = readConfig(self,varargin)
     %Usage: retval = readConfig (config, key, options)
     %
     %config is of type Property. key is of type std::string const &. options is of type ResourceFinderOptions const &. config is of type Property. key is of type std::string const &. options is of type ResourceFinderOptions const &. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(654, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(641, self, varargin{:});
     end
   end
   methods(Static)
@@ -164,43 +158,43 @@ classdef ResourceFinder < yarp.Searchable
     %Usage: retval = getResourceFinderSingleton ()
     %
     %retval is of type ResourceFinder. 
-     [varargout{1:nargout}] = yarpMEX(639, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(626, varargin{:});
     end
     function varargout = getDataHome(varargin)
     %Usage: retval = getDataHome ()
     %
     %retval is of type std::string. 
-     [varargout{1:nargout}] = yarpMEX(642, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(629, varargin{:});
     end
     function varargout = getDataHomeNoCreate(varargin)
     %Usage: retval = getDataHomeNoCreate ()
     %
     %retval is of type std::string. 
-     [varargout{1:nargout}] = yarpMEX(643, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(630, varargin{:});
     end
     function varargout = getConfigHome(varargin)
     %Usage: retval = getConfigHome ()
     %
     %retval is of type std::string. 
-     [varargout{1:nargout}] = yarpMEX(644, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(631, varargin{:});
     end
     function varargout = getConfigHomeNoCreate(varargin)
     %Usage: retval = getConfigHomeNoCreate ()
     %
     %retval is of type std::string. 
-     [varargout{1:nargout}] = yarpMEX(645, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(632, varargin{:});
     end
     function varargout = getDataDirs(varargin)
     %Usage: retval = getDataDirs ()
     %
     %retval is of type Bottle. 
-     [varargout{1:nargout}] = yarpMEX(648, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(635, varargin{:});
     end
     function varargout = getConfigDirs(varargin)
     %Usage: retval = getConfigDirs ()
     %
     %retval is of type Bottle. 
-     [varargout{1:nargout}] = yarpMEX(649, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(636, varargin{:});
     end
   end
 end

--- a/matlab/autogenerated/+yarp/ResourceFinder.m
+++ b/matlab/autogenerated/+yarp/ResourceFinder.m
@@ -1,11 +1,9 @@
-classdef ResourceFinder < SwigRef
+classdef ResourceFinder < yarp.Searchable
     %Usage: ResourceFinder ()
     %
   methods
-    function this = swig_this(self)
-      this = yarpMEX(3, self);
-    end
     function self = ResourceFinder(varargin)
+      self@yarp.Searchable(SwigRef.Null);
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;

--- a/matlab/autogenerated/+yarp/RpcClient.m
+++ b/matlab/autogenerated/+yarp/RpcClient.m
@@ -9,14 +9,14 @@ classdef RpcClient < yarp.AbstractContactable
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(664, varargin{:});
+        tmp = yarpMEX(650, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(665, self);
+        yarpMEX(651, self);
         self.SwigClear();
       end
     end
@@ -24,49 +24,49 @@ classdef RpcClient < yarp.AbstractContactable
     %Usage: retval = read (reader)
     %
     %reader is of type PortReader. reader is of type PortReader. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(666, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(652, self, varargin{:});
     end
     function varargout = reply(self,varargin)
     %Usage: retval = reply (writer)
     %
     %writer is of type PortWriter. writer is of type PortWriter. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(667, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(653, self, varargin{:});
     end
     function varargout = replyAndDrop(self,varargin)
     %Usage: retval = replyAndDrop (writer)
     %
     %writer is of type PortWriter. writer is of type PortWriter. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(668, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(654, self, varargin{:});
     end
     function varargout = setInputMode(self,varargin)
     %Usage: setInputMode (expectInput)
     %
     %expectInput is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(669, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(655, self, varargin{:});
     end
     function varargout = setOutputMode(self,varargin)
     %Usage: setOutputMode (expectOutput)
     %
     %expectOutput is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(670, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(656, self, varargin{:});
     end
     function varargout = setRpcMode(self,varargin)
     %Usage: setRpcMode (expectRpc)
     %
     %expectRpc is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(671, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(657, self, varargin{:});
     end
     function varargout = asPort(self,varargin)
     %Usage: retval = asPort ()
     %
     %retval is of type Port. 
-      [varargout{1:nargout}] = yarpMEX(672, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(658, self, varargin{:});
     end
     function varargout = write(self,varargin)
     %Usage: retval = write (data1, data2)
     %
     %data1 is of type Bottle. data2 is of type Bottle. data1 is of type Bottle. data2 is of type Bottle. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(673, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(659, self, varargin{:});
     end
   end
   methods(Static)

--- a/matlab/autogenerated/+yarp/RpcClient.m
+++ b/matlab/autogenerated/+yarp/RpcClient.m
@@ -1,11 +1,9 @@
-classdef RpcClient < SwigRef
+classdef RpcClient < yarp.AbstractContactable
     %Usage: RpcClient ()
     %
   methods
-    function this = swig_this(self)
-      this = yarpMEX(3, self);
-    end
     function self = RpcClient(varargin)
+      self@yarp.AbstractContactable(SwigRef.Null);
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;

--- a/matlab/autogenerated/+yarp/RpcServer.m
+++ b/matlab/autogenerated/+yarp/RpcServer.m
@@ -2,12 +2,6 @@ classdef RpcServer < yarp.AbstractContactable
     %Usage: RpcServer ()
     %
   methods
-    function varargout = open(self,varargin)
-    %Usage: retval = open (contact)
-    %
-    %contact is of type Contact. contact is of type Contact. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(655, self, varargin{:});
-    end
     function self = RpcServer(varargin)
       self@yarp.AbstractContactable(SwigRef.Null);
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -15,14 +9,14 @@ classdef RpcServer < yarp.AbstractContactable
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(656, varargin{:});
+        tmp = yarpMEX(642, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(657, self);
+        yarpMEX(643, self);
         self.SwigClear();
       end
     end
@@ -30,37 +24,37 @@ classdef RpcServer < yarp.AbstractContactable
     %Usage: retval = write (writer, reader)
     %
     %writer is of type PortWriter. reader is of type PortReader. writer is of type PortWriter. reader is of type PortReader. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(658, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(644, self, varargin{:});
     end
     function varargout = read(self,varargin)
     %Usage: retval = read (reader)
     %
     %reader is of type PortReader. reader is of type PortReader. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(659, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(645, self, varargin{:});
     end
     function varargout = setInputMode(self,varargin)
     %Usage: setInputMode (expectInput)
     %
     %expectInput is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(660, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(646, self, varargin{:});
     end
     function varargout = setOutputMode(self,varargin)
     %Usage: setOutputMode (expectOutput)
     %
     %expectOutput is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(661, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(647, self, varargin{:});
     end
     function varargout = setRpcMode(self,varargin)
     %Usage: setRpcMode (expectRpc)
     %
     %expectRpc is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(662, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(648, self, varargin{:});
     end
     function varargout = asPort(self,varargin)
     %Usage: retval = asPort ()
     %
     %retval is of type Port. 
-      [varargout{1:nargout}] = yarpMEX(663, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(649, self, varargin{:});
     end
   end
   methods(Static)

--- a/matlab/autogenerated/+yarp/RpcServer.m
+++ b/matlab/autogenerated/+yarp/RpcServer.m
@@ -1,10 +1,7 @@
-classdef RpcServer < SwigRef
+classdef RpcServer < yarp.AbstractContactable
     %Usage: RpcServer ()
     %
   methods
-    function this = swig_this(self)
-      this = yarpMEX(3, self);
-    end
     function varargout = open(self,varargin)
     %Usage: retval = open (contact)
     %
@@ -12,6 +9,7 @@ classdef RpcServer < SwigRef
       [varargout{1:nargout}] = yarpMEX(655, self, varargin{:});
     end
     function self = RpcServer(varargin)
+      self@yarp.AbstractContactable(SwigRef.Null);
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;

--- a/matlab/autogenerated/+yarp/SVector.m
+++ b/matlab/autogenerated/+yarp/SVector.m
@@ -9,89 +9,89 @@ classdef SVector < SwigRef
     %Usage: retval = pop ()
     %
     %retval is of type std::vector< std::string >::value_type. 
-      [varargout{1:nargout}] = yarpMEX(1837, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1823, self, varargin{:});
     end
     function varargout = brace(self,varargin)
     %Usage: retval = brace (i)
     %
     %i is of type std::vector< std::string >::difference_type. i is of type std::vector< std::string >::difference_type. retval is of type std::vector< std::string >::value_type. 
-      [varargout{1:nargout}] = yarpMEX(1838, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1824, self, varargin{:});
     end
     function varargout = setbrace(self,varargin)
     %Usage: setbrace (x, i)
     %
     %x is of type std::vector< std::string >::value_type. i is of type std::vector< std::string >::difference_type. 
-      [varargout{1:nargout}] = yarpMEX(1839, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1825, self, varargin{:});
     end
     function varargout = append(self,varargin)
     %Usage: append (x)
     %
     %x is of type std::vector< std::string >::value_type. 
-      [varargout{1:nargout}] = yarpMEX(1840, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1826, self, varargin{:});
     end
     function varargout = empty(self,varargin)
     %Usage: retval = empty ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1841, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1827, self, varargin{:});
     end
     function varargout = size(self,varargin)
     %Usage: retval = size ()
     %
     %retval is of type std::vector< std::string >::size_type. 
-      [varargout{1:nargout}] = yarpMEX(1842, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1828, self, varargin{:});
     end
     function varargout = swap(self,varargin)
     %Usage: swap (v)
     %
     %v is of type SVector. 
-      [varargout{1:nargout}] = yarpMEX(1843, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1829, self, varargin{:});
     end
     function varargout = begin(self,varargin)
     %Usage: retval = begin ()
     %
     %retval is of type std::vector< std::string >::iterator. 
-      [varargout{1:nargout}] = yarpMEX(1844, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1830, self, varargin{:});
     end
     function varargout = end(self,varargin)
     %Usage: retval = end ()
     %
     %retval is of type std::vector< std::string >::iterator. 
-      [varargout{1:nargout}] = yarpMEX(1845, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1831, self, varargin{:});
     end
     function varargout = rbegin(self,varargin)
     %Usage: retval = rbegin ()
     %
     %retval is of type std::vector< std::string >::reverse_iterator. 
-      [varargout{1:nargout}] = yarpMEX(1846, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1832, self, varargin{:});
     end
     function varargout = rend(self,varargin)
     %Usage: retval = rend ()
     %
     %retval is of type std::vector< std::string >::reverse_iterator. 
-      [varargout{1:nargout}] = yarpMEX(1847, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1833, self, varargin{:});
     end
     function varargout = clear(self,varargin)
     %Usage: clear ()
     %
-      [varargout{1:nargout}] = yarpMEX(1848, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1834, self, varargin{:});
     end
     function varargout = get_allocator(self,varargin)
     %Usage: retval = get_allocator ()
     %
     %retval is of type std::vector< std::string >::allocator_type. 
-      [varargout{1:nargout}] = yarpMEX(1849, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1835, self, varargin{:});
     end
     function varargout = pop_back(self,varargin)
     %Usage: pop_back ()
     %
-      [varargout{1:nargout}] = yarpMEX(1850, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1836, self, varargin{:});
     end
     function varargout = erase(self,varargin)
     %Usage: retval = erase (first, last)
     %
     %first is of type std::vector< std::string >::iterator. last is of type std::vector< std::string >::iterator. first is of type std::vector< std::string >::iterator. last is of type std::vector< std::string >::iterator. retval is of type std::vector< std::string >::iterator. 
-      [varargout{1:nargout}] = yarpMEX(1851, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1837, self, varargin{:});
     end
     function self = SVector(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -99,7 +99,7 @@ classdef SVector < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(1852, varargin{:});
+        tmp = yarpMEX(1838, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
@@ -108,53 +108,53 @@ classdef SVector < SwigRef
     %Usage: push_back (x)
     %
     %x is of type std::vector< std::string >::value_type const &. 
-      [varargout{1:nargout}] = yarpMEX(1853, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1839, self, varargin{:});
     end
     function varargout = front(self,varargin)
     %Usage: retval = front ()
     %
     %retval is of type std::vector< std::string >::value_type const &. 
-      [varargout{1:nargout}] = yarpMEX(1854, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1840, self, varargin{:});
     end
     function varargout = back(self,varargin)
     %Usage: retval = back ()
     %
     %retval is of type std::vector< std::string >::value_type const &. 
-      [varargout{1:nargout}] = yarpMEX(1855, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1841, self, varargin{:});
     end
     function varargout = assign(self,varargin)
     %Usage: assign (n, x)
     %
     %n is of type std::vector< std::string >::size_type. x is of type std::vector< std::string >::value_type const &. 
-      [varargout{1:nargout}] = yarpMEX(1856, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1842, self, varargin{:});
     end
     function varargout = resize(self,varargin)
     %Usage: resize (new_size, x)
     %
     %new_size is of type std::vector< std::string >::size_type. x is of type std::vector< std::string >::value_type const &. 
-      [varargout{1:nargout}] = yarpMEX(1857, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1843, self, varargin{:});
     end
     function varargout = insert(self,varargin)
     %Usage: insert (pos, n, x)
     %
     %pos is of type std::vector< std::string >::iterator. n is of type std::vector< std::string >::size_type. x is of type std::vector< std::string >::value_type const &. 
-      [varargout{1:nargout}] = yarpMEX(1858, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1844, self, varargin{:});
     end
     function varargout = reserve(self,varargin)
     %Usage: reserve (n)
     %
     %n is of type std::vector< std::string >::size_type. 
-      [varargout{1:nargout}] = yarpMEX(1859, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1845, self, varargin{:});
     end
     function varargout = capacity(self,varargin)
     %Usage: retval = capacity ()
     %
     %retval is of type std::vector< std::string >::size_type. 
-      [varargout{1:nargout}] = yarpMEX(1860, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1846, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1861, self);
+        yarpMEX(1847, self);
         self.SwigClear();
       end
     end

--- a/matlab/autogenerated/+yarp/SearchMonitor.m
+++ b/matlab/autogenerated/+yarp/SearchMonitor.m
@@ -7,7 +7,7 @@ classdef SearchMonitor < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(142, self);
+        yarpMEX(130, self);
         self.SwigClear();
       end
     end
@@ -15,7 +15,7 @@ classdef SearchMonitor < SwigRef
     %Usage: report (report, context)
     %
     %report is of type SearchReport. context is of type char const *. 
-      [varargout{1:nargout}] = yarpMEX(143, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(131, self, varargin{:});
     end
     function self = SearchMonitor(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/SearchReport.m
+++ b/matlab/autogenerated/+yarp/SearchReport.m
@@ -9,60 +9,60 @@ classdef SearchReport < SwigRef
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(128, self);
+        varargout{1} = yarpMEX(116, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(129, self, varargin{1});
+        yarpMEX(117, self, varargin{1});
       end
     end
     function varargout = value(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(130, self);
+        varargout{1} = yarpMEX(118, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(131, self, varargin{1});
+        yarpMEX(119, self, varargin{1});
       end
     end
     function varargout = isFound(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(132, self);
+        varargout{1} = yarpMEX(120, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(133, self, varargin{1});
+        yarpMEX(121, self, varargin{1});
       end
     end
     function varargout = isGroup(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(134, self);
+        varargout{1} = yarpMEX(122, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(135, self, varargin{1});
+        yarpMEX(123, self, varargin{1});
       end
     end
     function varargout = isComment(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(136, self);
+        varargout{1} = yarpMEX(124, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(137, self, varargin{1});
+        yarpMEX(125, self, varargin{1});
       end
     end
     function varargout = isDefault(self, varargin)
       narginchk(1, 2)
       if nargin==1
         nargoutchk(0, 1)
-        varargout{1} = yarpMEX(138, self);
+        varargout{1} = yarpMEX(126, self);
       else
         nargoutchk(0, 0)
-        yarpMEX(139, self, varargin{1});
+        yarpMEX(127, self, varargin{1});
       end
     end
     function self = SearchReport(varargin)
@@ -71,14 +71,14 @@ classdef SearchReport < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(140, varargin{:});
+        tmp = yarpMEX(128, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(141, self);
+        yarpMEX(129, self);
         self.SwigClear();
       end
     end

--- a/matlab/autogenerated/+yarp/Searchable.m
+++ b/matlab/autogenerated/+yarp/Searchable.m
@@ -7,7 +7,7 @@ classdef Searchable < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(144, self);
+        yarpMEX(132, self);
         self.SwigClear();
       end
     end
@@ -15,55 +15,55 @@ classdef Searchable < SwigRef
     %Usage: retval = find (key)
     %
     %key is of type std::string const &. key is of type std::string const &. retval is of type Value. 
-      [varargout{1:nargout}] = yarpMEX(145, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(133, self, varargin{:});
     end
     function varargout = findGroup(self,varargin)
     %Usage: retval = findGroup (key, comment)
     %
     %key is of type std::string const &. comment is of type std::string const &. key is of type std::string const &. comment is of type std::string const &. retval is of type Bottle. 
-      [varargout{1:nargout}] = yarpMEX(146, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(134, self, varargin{:});
     end
     function varargout = check(self,varargin)
     %Usage: retval = check (key, fallback)
     %
     %key is of type std::string const &. fallback is of type Value. key is of type std::string const &. fallback is of type Value. retval is of type Value. 
-      [varargout{1:nargout}] = yarpMEX(147, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(135, self, varargin{:});
     end
     function varargout = isNull(self,varargin)
     %Usage: retval = isNull ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(148, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(136, self, varargin{:});
     end
     function varargout = toString_c(self,varargin)
     %Usage: retval = toString_c ()
     %
     %retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(149, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(137, self, varargin{:});
     end
     function varargout = setMonitor(self,varargin)
     %Usage: setMonitor (monitor)
     %
     %monitor is of type SearchMonitor. 
-      [varargout{1:nargout}] = yarpMEX(150, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(138, self, varargin{:});
     end
     function varargout = getMonitor(self,varargin)
     %Usage: retval = getMonitor ()
     %
     %retval is of type SearchMonitor. 
-      [varargout{1:nargout}] = yarpMEX(151, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(139, self, varargin{:});
     end
     function varargout = getMonitorContext(self,varargin)
     %Usage: retval = getMonitorContext ()
     %
     %retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(152, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(140, self, varargin{:});
     end
     function varargout = reportToMonitor(self,varargin)
     %Usage: reportToMonitor (report)
     %
     %report is of type SearchReport. 
-      [varargout{1:nargout}] = yarpMEX(153, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(141, self, varargin{:});
     end
     function self = Searchable(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/Semaphore.m
+++ b/matlab/autogenerated/+yarp/Semaphore.m
@@ -11,38 +11,38 @@ classdef Semaphore < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(480, varargin{:});
+        tmp = yarpMEX(468, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(481, self);
+        yarpMEX(469, self);
         self.SwigClear();
       end
     end
     function varargout = wait(self,varargin)
     %Usage: wait ()
     %
-      [varargout{1:nargout}] = yarpMEX(482, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(470, self, varargin{:});
     end
     function varargout = waitWithTimeout(self,varargin)
     %Usage: retval = waitWithTimeout (timeoutInSeconds)
     %
     %timeoutInSeconds is of type double. timeoutInSeconds is of type double. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(483, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(471, self, varargin{:});
     end
     function varargout = check(self,varargin)
     %Usage: retval = check ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(484, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(472, self, varargin{:});
     end
     function varargout = post(self,varargin)
     %Usage: post ()
     %
-      [varargout{1:nargout}] = yarpMEX(485, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(473, self, varargin{:});
     end
   end
   methods(Static)

--- a/matlab/autogenerated/+yarp/Sound.m
+++ b/matlab/autogenerated/+yarp/Sound.m
@@ -9,14 +9,14 @@ classdef Sound < yarp.Portable
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(967, varargin{:});
+        tmp = yarpMEX(953, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(968, self);
+        yarpMEX(954, self);
         self.SwigClear();
       end
     end
@@ -24,102 +24,102 @@ classdef Sound < yarp.Portable
     %Usage: retval = subSound (first_sample, last_sample)
     %
     %first_sample is of type size_t. last_sample is of type size_t. first_sample is of type size_t. last_sample is of type size_t. retval is of type Sound. 
-      [varargout{1:nargout}] = yarpMEX(969, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(955, self, varargin{:});
     end
     function varargout = resize(self,varargin)
     %Usage: resize (samples)
     %
     %samples is of type size_t. 
-      [varargout{1:nargout}] = yarpMEX(970, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(956, self, varargin{:});
     end
     function varargout = get(self,varargin)
     %Usage: retval = get (sample)
     %
     %sample is of type size_t. sample is of type size_t. retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(971, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(957, self, varargin{:});
     end
     function varargout = set(self,varargin)
     %Usage: set (value, sample)
     %
     %value is of type int. sample is of type size_t. 
-      [varargout{1:nargout}] = yarpMEX(972, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(958, self, varargin{:});
     end
     function varargout = getSafe(self,varargin)
     %Usage: retval = getSafe (sample)
     %
     %sample is of type size_t. sample is of type size_t. retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(973, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(959, self, varargin{:});
     end
     function varargout = setSafe(self,varargin)
     %Usage: setSafe (value, sample)
     %
     %value is of type int. sample is of type size_t. 
-      [varargout{1:nargout}] = yarpMEX(974, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(960, self, varargin{:});
     end
     function varargout = isSample(self,varargin)
     %Usage: retval = isSample (sample)
     %
     %sample is of type size_t. sample is of type size_t. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(975, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(961, self, varargin{:});
     end
     function varargout = clear(self,varargin)
     %Usage: clear ()
     %
-      [varargout{1:nargout}] = yarpMEX(976, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(962, self, varargin{:});
     end
     function varargout = getFrequency(self,varargin)
     %Usage: retval = getFrequency ()
     %
     %retval is of type size_t. 
-      [varargout{1:nargout}] = yarpMEX(977, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(963, self, varargin{:});
     end
     function varargout = setFrequency(self,varargin)
     %Usage: setFrequency (freq)
     %
     %freq is of type size_t. 
-      [varargout{1:nargout}] = yarpMEX(978, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(964, self, varargin{:});
     end
     function varargout = getBytesPerSample(self,varargin)
     %Usage: retval = getBytesPerSample ()
     %
     %retval is of type size_t. 
-      [varargout{1:nargout}] = yarpMEX(979, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(965, self, varargin{:});
     end
     function varargout = getSamples(self,varargin)
     %Usage: retval = getSamples ()
     %
     %retval is of type size_t. 
-      [varargout{1:nargout}] = yarpMEX(980, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(966, self, varargin{:});
     end
     function varargout = getChannels(self,varargin)
     %Usage: retval = getChannels ()
     %
     %retval is of type size_t. 
-      [varargout{1:nargout}] = yarpMEX(981, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(967, self, varargin{:});
     end
     function varargout = read(self,varargin)
     %Usage: retval = read (connection)
     %
     %connection is of type ConnectionReader. connection is of type ConnectionReader. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(982, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(968, self, varargin{:});
     end
     function varargout = write(self,varargin)
     %Usage: retval = write (connection)
     %
     %connection is of type ConnectionWriter. connection is of type ConnectionWriter. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(983, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(969, self, varargin{:});
     end
     function varargout = getRawData(self,varargin)
     %Usage: retval = getRawData ()
     %
     %retval is of type unsigned char *. 
-      [varargout{1:nargout}] = yarpMEX(984, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(970, self, varargin{:});
     end
     function varargout = getRawDataSize(self,varargin)
     %Usage: retval = getRawDataSize ()
     %
     %retval is of type size_t. 
-      [varargout{1:nargout}] = yarpMEX(985, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(971, self, varargin{:});
     end
   end
   methods(Static)

--- a/matlab/autogenerated/+yarp/Sound.m
+++ b/matlab/autogenerated/+yarp/Sound.m
@@ -1,11 +1,9 @@
-classdef Sound < SwigRef
+classdef Sound < yarp.Portable
     %Usage: Sound ()
     %
   methods
-    function this = swig_this(self)
-      this = yarpMEX(3, self);
-    end
     function self = Sound(varargin)
+      self@yarp.Portable(SwigRef.Null);
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;

--- a/matlab/autogenerated/+yarp/Stamp.m
+++ b/matlab/autogenerated/+yarp/Stamp.m
@@ -1,11 +1,9 @@
-classdef Stamp < SwigRef
+classdef Stamp < yarp.Portable
     %Usage: Stamp ()
     %
   methods
-    function this = swig_this(self)
-      this = yarpMEX(3, self);
-    end
     function self = Stamp(varargin)
+      self@yarp.Portable(SwigRef.Null);
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;

--- a/matlab/autogenerated/+yarp/Stamp.m
+++ b/matlab/autogenerated/+yarp/Stamp.m
@@ -9,7 +9,7 @@ classdef Stamp < yarp.Portable
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(590, varargin{:});
+        tmp = yarpMEX(578, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
@@ -18,47 +18,47 @@ classdef Stamp < yarp.Portable
     %Usage: retval = getCount ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(591, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(579, self, varargin{:});
     end
     function varargout = getTime(self,varargin)
     %Usage: retval = getTime ()
     %
     %retval is of type double. 
-      [varargout{1:nargout}] = yarpMEX(592, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(580, self, varargin{:});
     end
     function varargout = isValid(self,varargin)
     %Usage: retval = isValid ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(593, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(581, self, varargin{:});
     end
     function varargout = getMaxCount(self,varargin)
     %Usage: retval = getMaxCount ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(594, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(582, self, varargin{:});
     end
     function varargout = update(self,varargin)
     %Usage: update (time)
     %
     %time is of type double. 
-      [varargout{1:nargout}] = yarpMEX(595, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(583, self, varargin{:});
     end
     function varargout = read(self,varargin)
     %Usage: retval = read (connection)
     %
     %connection is of type ConnectionReader. connection is of type ConnectionReader. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(596, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(584, self, varargin{:});
     end
     function varargout = write(self,varargin)
     %Usage: retval = write (connection)
     %
     %connection is of type ConnectionWriter. connection is of type ConnectionWriter. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(597, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(585, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(598, self);
+        yarpMEX(586, self);
         self.SwigClear();
       end
     end

--- a/matlab/autogenerated/+yarp/Stamped.m
+++ b/matlab/autogenerated/+yarp/Stamped.m
@@ -7,7 +7,7 @@ classdef Stamped < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(599, self);
+        yarpMEX(587, self);
         self.SwigClear();
       end
     end
@@ -15,7 +15,7 @@ classdef Stamped < SwigRef
     %Usage: retval = getStamp ()
     %
     %retval is of type Stamp. 
-      [varargout{1:nargout}] = yarpMEX(600, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(588, self, varargin{:});
     end
     function self = Stamped(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/StubDriverCreator.m
+++ b/matlab/autogenerated/+yarp/StubDriverCreator.m
@@ -1,11 +1,9 @@
-classdef StubDriverCreator < SwigRef
+classdef StubDriverCreator < yarp.DriverCreator
     %Usage: StubDriverCreator ()
     %
   methods
-    function this = swig_this(self)
-      this = yarpMEX(3, self);
-    end
     function self = StubDriverCreator(varargin)
+      self@yarp.DriverCreator(SwigRef.Null);
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;

--- a/matlab/autogenerated/+yarp/StubDriverCreator.m
+++ b/matlab/autogenerated/+yarp/StubDriverCreator.m
@@ -9,44 +9,44 @@ classdef StubDriverCreator < yarp.DriverCreator
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(1112, varargin{:});
+        tmp = yarpMEX(1098, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
-    function varargout = toString(self,varargin)
-    %Usage: retval = toString ()
+    function varargout = toString_c(self,varargin)
+    %Usage: retval = toString_c ()
     %
     %retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(1113, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1099, self, varargin{:});
     end
     function varargout = getName(self,varargin)
     %Usage: retval = getName ()
     %
     %retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(1114, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1100, self, varargin{:});
     end
     function varargout = getWrapper(self,varargin)
     %Usage: retval = getWrapper ()
     %
     %retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(1115, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1101, self, varargin{:});
     end
     function varargout = getCode(self,varargin)
     %Usage: retval = getCode ()
     %
     %retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(1116, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1102, self, varargin{:});
     end
     function varargout = create(self,varargin)
     %Usage: retval = create ()
     %
     %retval is of type DeviceDriver. 
-      [varargout{1:nargout}] = yarpMEX(1117, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1103, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1118, self);
+        yarpMEX(1104, self);
         self.SwigClear();
       end
     end

--- a/matlab/autogenerated/+yarp/SystemRateThread.m
+++ b/matlab/autogenerated/+yarp/SystemRateThread.m
@@ -1,10 +1,7 @@
-classdef SystemRateThread < SwigRef
+classdef SystemRateThread < yarp.PeriodicThread
     %Usage: SystemRateThread ()
     %
   methods
-    function this = swig_this(self)
-      this = yarpMEX(3, self);
-    end
     function delete(self)
       if self.swigPtr
         yarpMEX(543, self);
@@ -18,6 +15,7 @@ classdef SystemRateThread < SwigRef
       [varargout{1:nargout}] = yarpMEX(544, self, varargin{:});
     end
     function self = SystemRateThread(varargin)
+      self@yarp.PeriodicThread(SwigRef.Null);
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;

--- a/matlab/autogenerated/+yarp/SystemRateThread.m
+++ b/matlab/autogenerated/+yarp/SystemRateThread.m
@@ -4,7 +4,7 @@ classdef SystemRateThread < yarp.PeriodicThread
   methods
     function delete(self)
       if self.swigPtr
-        yarpMEX(543, self);
+        yarpMEX(531, self);
         self.SwigClear();
       end
     end
@@ -12,7 +12,7 @@ classdef SystemRateThread < yarp.PeriodicThread
     %Usage: retval = stepSystem ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(544, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(532, self, varargin{:});
     end
     function self = SystemRateThread(varargin)
       self@yarp.PeriodicThread(SwigRef.Null);

--- a/matlab/autogenerated/+yarp/Things.m
+++ b/matlab/autogenerated/+yarp/Things.m
@@ -11,14 +11,14 @@ classdef Things < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(681, varargin{:});
+        tmp = yarpMEX(667, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(682, self);
+        yarpMEX(668, self);
         self.SwigClear();
       end
     end
@@ -26,102 +26,102 @@ classdef Things < SwigRef
     %Usage: setPortWriter (writer)
     %
     %writer is of type PortWriter. 
-      [varargout{1:nargout}] = yarpMEX(683, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(669, self, varargin{:});
     end
     function varargout = getPortWriter(self,varargin)
     %Usage: retval = getPortWriter ()
     %
     %retval is of type PortWriter. 
-      [varargout{1:nargout}] = yarpMEX(684, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(670, self, varargin{:});
     end
     function varargout = setPortReader(self,varargin)
     %Usage: setPortReader (reader)
     %
     %reader is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(685, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(671, self, varargin{:});
     end
     function varargout = getPortReader(self,varargin)
     %Usage: retval = getPortReader ()
     %
     %retval is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(686, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(672, self, varargin{:});
     end
     function varargout = setConnectionReader(self,varargin)
     %Usage: retval = setConnectionReader (reader)
     %
     %reader is of type ConnectionReader. reader is of type ConnectionReader. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(687, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(673, self, varargin{:});
     end
     function varargout = write(self,varargin)
     %Usage: retval = write (connection)
     %
     %connection is of type ConnectionWriter. connection is of type ConnectionWriter. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(688, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(674, self, varargin{:});
     end
     function varargout = reset(self,varargin)
     %Usage: reset ()
     %
-      [varargout{1:nargout}] = yarpMEX(689, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(675, self, varargin{:});
     end
     function varargout = hasBeenRead(self,varargin)
     %Usage: retval = hasBeenRead ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(690, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(676, self, varargin{:});
     end
     function varargout = asValue(self,varargin)
     %Usage: retval = asValue ()
     %
     %retval is of type Value. 
-      [varargout{1:nargout}] = yarpMEX(691, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(677, self, varargin{:});
     end
     function varargout = asBottle(self,varargin)
     %Usage: retval = asBottle ()
     %
     %retval is of type Bottle. 
-      [varargout{1:nargout}] = yarpMEX(692, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(678, self, varargin{:});
     end
     function varargout = asProperty(self,varargin)
     %Usage: retval = asProperty ()
     %
     %retval is of type Property. 
-      [varargout{1:nargout}] = yarpMEX(693, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(679, self, varargin{:});
     end
     function varargout = asVector(self,varargin)
     %Usage: retval = asVector ()
     %
     %retval is of type Vector. 
-      [varargout{1:nargout}] = yarpMEX(694, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(680, self, varargin{:});
     end
     function varargout = asMatrix(self,varargin)
     %Usage: retval = asMatrix ()
     %
     %retval is of type Matrix. 
-      [varargout{1:nargout}] = yarpMEX(695, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(681, self, varargin{:});
     end
     function varargout = asImage(self,varargin)
     %Usage: retval = asImage ()
     %
     %retval is of type Image. 
-      [varargout{1:nargout}] = yarpMEX(696, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(682, self, varargin{:});
     end
     function varargout = asImageOfPixelRgb(self,varargin)
     %Usage: retval = asImageOfPixelRgb ()
     %
     %retval is of type ImageRgb. 
-      [varargout{1:nargout}] = yarpMEX(697, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(683, self, varargin{:});
     end
     function varargout = asImageOfPixelBgr(self,varargin)
     %Usage: retval = asImageOfPixelBgr ()
     %
     %retval is of type yarp::sig::ImageOf< yarp::sig::PixelBgr > *. 
-      [varargout{1:nargout}] = yarpMEX(698, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(684, self, varargin{:});
     end
     function varargout = asImageOfPixelMono(self,varargin)
     %Usage: retval = asImageOfPixelMono ()
     %
     %retval is of type ImageMono. 
-      [varargout{1:nargout}] = yarpMEX(699, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(685, self, varargin{:});
     end
   end
   methods(Static)

--- a/matlab/autogenerated/+yarp/Thread.m
+++ b/matlab/autogenerated/+yarp/Thread.m
@@ -7,100 +7,100 @@ classdef Thread < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(486, self);
+        yarpMEX(474, self);
         self.SwigClear();
       end
     end
     function varargout = run(self,varargin)
     %Usage: run ()
     %
-      [varargout{1:nargout}] = yarpMEX(487, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(475, self, varargin{:});
     end
     function varargout = onStop(self,varargin)
     %Usage: onStop ()
     %
-      [varargout{1:nargout}] = yarpMEX(488, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(476, self, varargin{:});
     end
     function varargout = start(self,varargin)
     %Usage: retval = start ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(489, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(477, self, varargin{:});
     end
     function varargout = stop(self,varargin)
     %Usage: retval = stop ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(490, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(478, self, varargin{:});
     end
     function varargout = beforeStart(self,varargin)
     %Usage: beforeStart ()
     %
-      [varargout{1:nargout}] = yarpMEX(491, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(479, self, varargin{:});
     end
     function varargout = afterStart(self,varargin)
     %Usage: afterStart (success)
     %
     %success is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(492, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(480, self, varargin{:});
     end
     function varargout = threadInit(self,varargin)
     %Usage: retval = threadInit ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(493, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(481, self, varargin{:});
     end
     function varargout = threadRelease(self,varargin)
     %Usage: threadRelease ()
     %
-      [varargout{1:nargout}] = yarpMEX(494, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(482, self, varargin{:});
     end
     function varargout = isStopping(self,varargin)
     %Usage: retval = isStopping ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(495, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(483, self, varargin{:});
     end
     function varargout = isRunning(self,varargin)
     %Usage: retval = isRunning ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(496, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(484, self, varargin{:});
     end
     function varargout = getKey(self,varargin)
     %Usage: retval = getKey ()
     %
     %retval is of type long. 
-      [varargout{1:nargout}] = yarpMEX(498, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(486, self, varargin{:});
     end
     function varargout = setPriority(self,varargin)
     %Usage: retval = setPriority (priority)
     %
     %priority is of type int. priority is of type int. retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(500, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(488, self, varargin{:});
     end
     function varargout = getPriority(self,varargin)
     %Usage: retval = getPriority ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(501, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(489, self, varargin{:});
     end
     function varargout = getPolicy(self,varargin)
     %Usage: retval = getPolicy ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(502, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(490, self, varargin{:});
     end
     function varargout = join(self,varargin)
     %Usage: retval = join ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(503, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(491, self, varargin{:});
     end
     function varargout = setOptions(self,varargin)
     %Usage: setOptions ()
     %
-      [varargout{1:nargout}] = yarpMEX(505, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(493, self, varargin{:});
     end
     function self = Thread(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -117,24 +117,24 @@ classdef Thread < SwigRef
     %Usage: retval = getCount ()
     %
     %retval is of type int. 
-     [varargout{1:nargout}] = yarpMEX(497, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(485, varargin{:});
     end
     function varargout = getKeyOfCaller(varargin)
     %Usage: retval = getKeyOfCaller ()
     %
     %retval is of type long. 
-     [varargout{1:nargout}] = yarpMEX(499, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(487, varargin{:});
     end
     function varargout = yield(varargin)
     %Usage: yield ()
     %
-     [varargout{1:nargout}] = yarpMEX(504, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(492, varargin{:});
     end
     function varargout = setDefaultStackSize(varargin)
     %Usage: setDefaultStackSize (stackSize)
     %
     %stackSize is of type int. 
-     [varargout{1:nargout}] = yarpMEX(506, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(494, varargin{:});
     end
   end
 end

--- a/matlab/autogenerated/+yarp/TypedReaderBottle.m
+++ b/matlab/autogenerated/+yarp/TypedReaderBottle.m
@@ -8,51 +8,51 @@ classdef TypedReaderBottle < SwigRef
     function varargout = setStrict(self,varargin)
     %Usage: setStrict ()
     %
-      [varargout{1:nargout}] = yarpMEX(792, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(778, self, varargin{:});
     end
     function varargout = read(self,varargin)
     %Usage: retval = read ()
     %
     %retval is of type Bottle. 
-      [varargout{1:nargout}] = yarpMEX(793, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(779, self, varargin{:});
     end
     function varargout = interrupt(self,varargin)
     %Usage: interrupt ()
     %
-      [varargout{1:nargout}] = yarpMEX(794, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(780, self, varargin{:});
     end
     function varargout = lastRead(self,varargin)
     %Usage: retval = lastRead ()
     %
     %retval is of type Bottle. 
-      [varargout{1:nargout}] = yarpMEX(795, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(781, self, varargin{:});
     end
     function varargout = isClosed(self,varargin)
     %Usage: retval = isClosed ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(796, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(782, self, varargin{:});
     end
     function varargout = useCallback(self,varargin)
     %Usage: useCallback (callback)
     %
     %callback is of type BottleCallback. 
-      [varargout{1:nargout}] = yarpMEX(797, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(783, self, varargin{:});
     end
     function varargout = disableCallback(self,varargin)
     %Usage: disableCallback ()
     %
-      [varargout{1:nargout}] = yarpMEX(798, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(784, self, varargin{:});
     end
     function varargout = getPendingReads(self,varargin)
     %Usage: retval = getPendingReads ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(799, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(785, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(800, self);
+        yarpMEX(786, self);
         self.SwigClear();
       end
     end
@@ -60,31 +60,31 @@ classdef TypedReaderBottle < SwigRef
     %Usage: retval = getName ()
     %
     %retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(801, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(787, self, varargin{:});
     end
     function varargout = setReplier(self,varargin)
     %Usage: setReplier (reader)
     %
     %reader is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(802, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(788, self, varargin{:});
     end
     function varargout = acquire(self,varargin)
     %Usage: retval = acquire ()
     %
     %retval is of type void *. 
-      [varargout{1:nargout}] = yarpMEX(803, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(789, self, varargin{:});
     end
     function varargout = release(self,varargin)
     %Usage: release (handle)
     %
     %handle is of type void *. 
-      [varargout{1:nargout}] = yarpMEX(804, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(790, self, varargin{:});
     end
     function varargout = setTargetPeriod(self,varargin)
     %Usage: setTargetPeriod (period)
     %
     %period is of type double. 
-      [varargout{1:nargout}] = yarpMEX(805, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(791, self, varargin{:});
     end
     function self = TypedReaderBottle(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/TypedReaderCallbackImageFloat.m
+++ b/matlab/autogenerated/+yarp/TypedReaderCallbackImageFloat.m
@@ -7,7 +7,7 @@ classdef TypedReaderCallbackImageFloat < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(2430, self);
+        yarpMEX(2416, self);
         self.SwigClear();
       end
     end
@@ -15,7 +15,7 @@ classdef TypedReaderCallbackImageFloat < SwigRef
     %Usage: onRead (datum, reader)
     %
     %datum is of type ImageFloat. reader is of type TypedReaderImageFloat. 
-      [varargout{1:nargout}] = yarpMEX(2431, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2417, self, varargin{:});
     end
     function self = TypedReaderCallbackImageFloat(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -23,7 +23,7 @@ classdef TypedReaderCallbackImageFloat < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(2432, varargin{:});
+        tmp = yarpMEX(2418, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end

--- a/matlab/autogenerated/+yarp/TypedReaderCallbackImageInt.m
+++ b/matlab/autogenerated/+yarp/TypedReaderCallbackImageInt.m
@@ -7,7 +7,7 @@ classdef TypedReaderCallbackImageInt < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(2226, self);
+        yarpMEX(2212, self);
         self.SwigClear();
       end
     end
@@ -15,7 +15,7 @@ classdef TypedReaderCallbackImageInt < SwigRef
     %Usage: onRead (datum, reader)
     %
     %datum is of type ImageInt. reader is of type TypedReaderImageInt. 
-      [varargout{1:nargout}] = yarpMEX(2227, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2213, self, varargin{:});
     end
     function self = TypedReaderCallbackImageInt(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -23,7 +23,7 @@ classdef TypedReaderCallbackImageInt < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(2228, varargin{:});
+        tmp = yarpMEX(2214, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end

--- a/matlab/autogenerated/+yarp/TypedReaderCallbackImageMono.m
+++ b/matlab/autogenerated/+yarp/TypedReaderCallbackImageMono.m
@@ -7,7 +7,7 @@ classdef TypedReaderCallbackImageMono < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(2080, self);
+        yarpMEX(2066, self);
         self.SwigClear();
       end
     end
@@ -15,7 +15,7 @@ classdef TypedReaderCallbackImageMono < SwigRef
     %Usage: onRead (datum, reader)
     %
     %datum is of type ImageMono. reader is of type TypedReaderImageMono. 
-      [varargout{1:nargout}] = yarpMEX(2081, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2067, self, varargin{:});
     end
     function self = TypedReaderCallbackImageMono(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -23,7 +23,7 @@ classdef TypedReaderCallbackImageMono < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(2082, varargin{:});
+        tmp = yarpMEX(2068, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end

--- a/matlab/autogenerated/+yarp/TypedReaderCallbackImageMono16.m
+++ b/matlab/autogenerated/+yarp/TypedReaderCallbackImageMono16.m
@@ -7,7 +7,7 @@ classdef TypedReaderCallbackImageMono16 < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(2152, self);
+        yarpMEX(2138, self);
         self.SwigClear();
       end
     end
@@ -15,7 +15,7 @@ classdef TypedReaderCallbackImageMono16 < SwigRef
     %Usage: onRead (datum, reader)
     %
     %datum is of type ImageMono16. reader is of type TypedReaderImageMono16. 
-      [varargout{1:nargout}] = yarpMEX(2153, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2139, self, varargin{:});
     end
     function self = TypedReaderCallbackImageMono16(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -23,7 +23,7 @@ classdef TypedReaderCallbackImageMono16 < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(2154, varargin{:});
+        tmp = yarpMEX(2140, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end

--- a/matlab/autogenerated/+yarp/TypedReaderCallbackImageRgb.m
+++ b/matlab/autogenerated/+yarp/TypedReaderCallbackImageRgb.m
@@ -7,7 +7,7 @@ classdef TypedReaderCallbackImageRgb < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1936, self);
+        yarpMEX(1922, self);
         self.SwigClear();
       end
     end
@@ -15,7 +15,7 @@ classdef TypedReaderCallbackImageRgb < SwigRef
     %Usage: onRead (datum, reader)
     %
     %datum is of type ImageRgb. reader is of type TypedReaderImageRgb. 
-      [varargout{1:nargout}] = yarpMEX(1937, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1923, self, varargin{:});
     end
     function self = TypedReaderCallbackImageRgb(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -23,7 +23,7 @@ classdef TypedReaderCallbackImageRgb < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(1938, varargin{:});
+        tmp = yarpMEX(1924, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end

--- a/matlab/autogenerated/+yarp/TypedReaderCallbackImageRgbFloat.m
+++ b/matlab/autogenerated/+yarp/TypedReaderCallbackImageRgbFloat.m
@@ -7,7 +7,7 @@ classdef TypedReaderCallbackImageRgbFloat < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(2502, self);
+        yarpMEX(2488, self);
         self.SwigClear();
       end
     end
@@ -15,7 +15,7 @@ classdef TypedReaderCallbackImageRgbFloat < SwigRef
     %Usage: onRead (datum, reader)
     %
     %datum is of type ImageRgbFloat. reader is of type TypedReaderImageRgbFloat. 
-      [varargout{1:nargout}] = yarpMEX(2503, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2489, self, varargin{:});
     end
     function self = TypedReaderCallbackImageRgbFloat(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -23,7 +23,7 @@ classdef TypedReaderCallbackImageRgbFloat < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(2504, varargin{:});
+        tmp = yarpMEX(2490, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end

--- a/matlab/autogenerated/+yarp/TypedReaderCallbackImageRgba.m
+++ b/matlab/autogenerated/+yarp/TypedReaderCallbackImageRgba.m
@@ -7,7 +7,7 @@ classdef TypedReaderCallbackImageRgba < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(2008, self);
+        yarpMEX(1994, self);
         self.SwigClear();
       end
     end
@@ -15,7 +15,7 @@ classdef TypedReaderCallbackImageRgba < SwigRef
     %Usage: onRead (datum, reader)
     %
     %datum is of type ImageRgba. reader is of type TypedReaderImageRgba. 
-      [varargout{1:nargout}] = yarpMEX(2009, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1995, self, varargin{:});
     end
     function self = TypedReaderCallbackImageRgba(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -23,7 +23,7 @@ classdef TypedReaderCallbackImageRgba < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(2010, varargin{:});
+        tmp = yarpMEX(1996, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end

--- a/matlab/autogenerated/+yarp/TypedReaderCallbackSound.m
+++ b/matlab/autogenerated/+yarp/TypedReaderCallbackSound.m
@@ -7,7 +7,7 @@ classdef TypedReaderCallbackSound < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(2291, self);
+        yarpMEX(2277, self);
         self.SwigClear();
       end
     end
@@ -15,7 +15,7 @@ classdef TypedReaderCallbackSound < SwigRef
     %Usage: onRead (datum, reader)
     %
     %datum is of type Sound. reader is of type TypedReaderSound. 
-      [varargout{1:nargout}] = yarpMEX(2292, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2278, self, varargin{:});
     end
     function self = TypedReaderCallbackSound(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -23,7 +23,7 @@ classdef TypedReaderCallbackSound < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(2293, varargin{:});
+        tmp = yarpMEX(2279, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end

--- a/matlab/autogenerated/+yarp/TypedReaderCallbackVector.m
+++ b/matlab/autogenerated/+yarp/TypedReaderCallbackVector.m
@@ -7,7 +7,7 @@ classdef TypedReaderCallbackVector < SwigRef
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(2356, self);
+        yarpMEX(2342, self);
         self.SwigClear();
       end
     end
@@ -15,7 +15,7 @@ classdef TypedReaderCallbackVector < SwigRef
     %Usage: onRead (datum, reader)
     %
     %datum is of type Vector. reader is of type TypedReaderVector. 
-      [varargout{1:nargout}] = yarpMEX(2357, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2343, self, varargin{:});
     end
     function self = TypedReaderCallbackVector(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
@@ -23,7 +23,7 @@ classdef TypedReaderCallbackVector < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(2358, varargin{:});
+        tmp = yarpMEX(2344, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end

--- a/matlab/autogenerated/+yarp/TypedReaderImageFloat.m
+++ b/matlab/autogenerated/+yarp/TypedReaderImageFloat.m
@@ -8,51 +8,51 @@ classdef TypedReaderImageFloat < SwigRef
     function varargout = setStrict(self,varargin)
     %Usage: setStrict ()
     %
-      [varargout{1:nargout}] = yarpMEX(2416, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2402, self, varargin{:});
     end
     function varargout = read(self,varargin)
     %Usage: retval = read ()
     %
     %retval is of type ImageFloat. 
-      [varargout{1:nargout}] = yarpMEX(2417, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2403, self, varargin{:});
     end
     function varargout = interrupt(self,varargin)
     %Usage: interrupt ()
     %
-      [varargout{1:nargout}] = yarpMEX(2418, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2404, self, varargin{:});
     end
     function varargout = lastRead(self,varargin)
     %Usage: retval = lastRead ()
     %
     %retval is of type ImageFloat. 
-      [varargout{1:nargout}] = yarpMEX(2419, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2405, self, varargin{:});
     end
     function varargout = isClosed(self,varargin)
     %Usage: retval = isClosed ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2420, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2406, self, varargin{:});
     end
     function varargout = useCallback(self,varargin)
     %Usage: useCallback (callback)
     %
     %callback is of type TypedReaderCallbackImageFloat. 
-      [varargout{1:nargout}] = yarpMEX(2421, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2407, self, varargin{:});
     end
     function varargout = disableCallback(self,varargin)
     %Usage: disableCallback ()
     %
-      [varargout{1:nargout}] = yarpMEX(2422, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2408, self, varargin{:});
     end
     function varargout = getPendingReads(self,varargin)
     %Usage: retval = getPendingReads ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(2423, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2409, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(2424, self);
+        yarpMEX(2410, self);
         self.SwigClear();
       end
     end
@@ -60,31 +60,31 @@ classdef TypedReaderImageFloat < SwigRef
     %Usage: retval = getName ()
     %
     %retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(2425, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2411, self, varargin{:});
     end
     function varargout = setReplier(self,varargin)
     %Usage: setReplier (reader)
     %
     %reader is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(2426, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2412, self, varargin{:});
     end
     function varargout = acquire(self,varargin)
     %Usage: retval = acquire ()
     %
     %retval is of type void *. 
-      [varargout{1:nargout}] = yarpMEX(2427, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2413, self, varargin{:});
     end
     function varargout = release(self,varargin)
     %Usage: release (handle)
     %
     %handle is of type void *. 
-      [varargout{1:nargout}] = yarpMEX(2428, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2414, self, varargin{:});
     end
     function varargout = setTargetPeriod(self,varargin)
     %Usage: setTargetPeriod (period)
     %
     %period is of type double. 
-      [varargout{1:nargout}] = yarpMEX(2429, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2415, self, varargin{:});
     end
     function self = TypedReaderImageFloat(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/TypedReaderImageInt.m
+++ b/matlab/autogenerated/+yarp/TypedReaderImageInt.m
@@ -8,51 +8,51 @@ classdef TypedReaderImageInt < SwigRef
     function varargout = setStrict(self,varargin)
     %Usage: setStrict ()
     %
-      [varargout{1:nargout}] = yarpMEX(2212, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2198, self, varargin{:});
     end
     function varargout = read(self,varargin)
     %Usage: retval = read ()
     %
     %retval is of type ImageInt. 
-      [varargout{1:nargout}] = yarpMEX(2213, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2199, self, varargin{:});
     end
     function varargout = interrupt(self,varargin)
     %Usage: interrupt ()
     %
-      [varargout{1:nargout}] = yarpMEX(2214, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2200, self, varargin{:});
     end
     function varargout = lastRead(self,varargin)
     %Usage: retval = lastRead ()
     %
     %retval is of type ImageInt. 
-      [varargout{1:nargout}] = yarpMEX(2215, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2201, self, varargin{:});
     end
     function varargout = isClosed(self,varargin)
     %Usage: retval = isClosed ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2216, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2202, self, varargin{:});
     end
     function varargout = useCallback(self,varargin)
     %Usage: useCallback (callback)
     %
     %callback is of type TypedReaderCallbackImageInt. 
-      [varargout{1:nargout}] = yarpMEX(2217, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2203, self, varargin{:});
     end
     function varargout = disableCallback(self,varargin)
     %Usage: disableCallback ()
     %
-      [varargout{1:nargout}] = yarpMEX(2218, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2204, self, varargin{:});
     end
     function varargout = getPendingReads(self,varargin)
     %Usage: retval = getPendingReads ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(2219, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2205, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(2220, self);
+        yarpMEX(2206, self);
         self.SwigClear();
       end
     end
@@ -60,31 +60,31 @@ classdef TypedReaderImageInt < SwigRef
     %Usage: retval = getName ()
     %
     %retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(2221, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2207, self, varargin{:});
     end
     function varargout = setReplier(self,varargin)
     %Usage: setReplier (reader)
     %
     %reader is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(2222, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2208, self, varargin{:});
     end
     function varargout = acquire(self,varargin)
     %Usage: retval = acquire ()
     %
     %retval is of type void *. 
-      [varargout{1:nargout}] = yarpMEX(2223, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2209, self, varargin{:});
     end
     function varargout = release(self,varargin)
     %Usage: release (handle)
     %
     %handle is of type void *. 
-      [varargout{1:nargout}] = yarpMEX(2224, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2210, self, varargin{:});
     end
     function varargout = setTargetPeriod(self,varargin)
     %Usage: setTargetPeriod (period)
     %
     %period is of type double. 
-      [varargout{1:nargout}] = yarpMEX(2225, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2211, self, varargin{:});
     end
     function self = TypedReaderImageInt(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/TypedReaderImageMono.m
+++ b/matlab/autogenerated/+yarp/TypedReaderImageMono.m
@@ -8,51 +8,51 @@ classdef TypedReaderImageMono < SwigRef
     function varargout = setStrict(self,varargin)
     %Usage: setStrict ()
     %
-      [varargout{1:nargout}] = yarpMEX(2066, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2052, self, varargin{:});
     end
     function varargout = read(self,varargin)
     %Usage: retval = read ()
     %
     %retval is of type ImageMono. 
-      [varargout{1:nargout}] = yarpMEX(2067, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2053, self, varargin{:});
     end
     function varargout = interrupt(self,varargin)
     %Usage: interrupt ()
     %
-      [varargout{1:nargout}] = yarpMEX(2068, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2054, self, varargin{:});
     end
     function varargout = lastRead(self,varargin)
     %Usage: retval = lastRead ()
     %
     %retval is of type ImageMono. 
-      [varargout{1:nargout}] = yarpMEX(2069, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2055, self, varargin{:});
     end
     function varargout = isClosed(self,varargin)
     %Usage: retval = isClosed ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2070, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2056, self, varargin{:});
     end
     function varargout = useCallback(self,varargin)
     %Usage: useCallback (callback)
     %
     %callback is of type TypedReaderCallbackImageMono. 
-      [varargout{1:nargout}] = yarpMEX(2071, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2057, self, varargin{:});
     end
     function varargout = disableCallback(self,varargin)
     %Usage: disableCallback ()
     %
-      [varargout{1:nargout}] = yarpMEX(2072, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2058, self, varargin{:});
     end
     function varargout = getPendingReads(self,varargin)
     %Usage: retval = getPendingReads ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(2073, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2059, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(2074, self);
+        yarpMEX(2060, self);
         self.SwigClear();
       end
     end
@@ -60,31 +60,31 @@ classdef TypedReaderImageMono < SwigRef
     %Usage: retval = getName ()
     %
     %retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(2075, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2061, self, varargin{:});
     end
     function varargout = setReplier(self,varargin)
     %Usage: setReplier (reader)
     %
     %reader is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(2076, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2062, self, varargin{:});
     end
     function varargout = acquire(self,varargin)
     %Usage: retval = acquire ()
     %
     %retval is of type void *. 
-      [varargout{1:nargout}] = yarpMEX(2077, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2063, self, varargin{:});
     end
     function varargout = release(self,varargin)
     %Usage: release (handle)
     %
     %handle is of type void *. 
-      [varargout{1:nargout}] = yarpMEX(2078, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2064, self, varargin{:});
     end
     function varargout = setTargetPeriod(self,varargin)
     %Usage: setTargetPeriod (period)
     %
     %period is of type double. 
-      [varargout{1:nargout}] = yarpMEX(2079, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2065, self, varargin{:});
     end
     function self = TypedReaderImageMono(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/TypedReaderImageMono16.m
+++ b/matlab/autogenerated/+yarp/TypedReaderImageMono16.m
@@ -8,51 +8,51 @@ classdef TypedReaderImageMono16 < SwigRef
     function varargout = setStrict(self,varargin)
     %Usage: setStrict ()
     %
-      [varargout{1:nargout}] = yarpMEX(2138, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2124, self, varargin{:});
     end
     function varargout = read(self,varargin)
     %Usage: retval = read ()
     %
     %retval is of type ImageMono16. 
-      [varargout{1:nargout}] = yarpMEX(2139, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2125, self, varargin{:});
     end
     function varargout = interrupt(self,varargin)
     %Usage: interrupt ()
     %
-      [varargout{1:nargout}] = yarpMEX(2140, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2126, self, varargin{:});
     end
     function varargout = lastRead(self,varargin)
     %Usage: retval = lastRead ()
     %
     %retval is of type ImageMono16. 
-      [varargout{1:nargout}] = yarpMEX(2141, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2127, self, varargin{:});
     end
     function varargout = isClosed(self,varargin)
     %Usage: retval = isClosed ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2142, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2128, self, varargin{:});
     end
     function varargout = useCallback(self,varargin)
     %Usage: useCallback (callback)
     %
     %callback is of type TypedReaderCallbackImageMono16. 
-      [varargout{1:nargout}] = yarpMEX(2143, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2129, self, varargin{:});
     end
     function varargout = disableCallback(self,varargin)
     %Usage: disableCallback ()
     %
-      [varargout{1:nargout}] = yarpMEX(2144, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2130, self, varargin{:});
     end
     function varargout = getPendingReads(self,varargin)
     %Usage: retval = getPendingReads ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(2145, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2131, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(2146, self);
+        yarpMEX(2132, self);
         self.SwigClear();
       end
     end
@@ -60,31 +60,31 @@ classdef TypedReaderImageMono16 < SwigRef
     %Usage: retval = getName ()
     %
     %retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(2147, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2133, self, varargin{:});
     end
     function varargout = setReplier(self,varargin)
     %Usage: setReplier (reader)
     %
     %reader is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(2148, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2134, self, varargin{:});
     end
     function varargout = acquire(self,varargin)
     %Usage: retval = acquire ()
     %
     %retval is of type void *. 
-      [varargout{1:nargout}] = yarpMEX(2149, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2135, self, varargin{:});
     end
     function varargout = release(self,varargin)
     %Usage: release (handle)
     %
     %handle is of type void *. 
-      [varargout{1:nargout}] = yarpMEX(2150, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2136, self, varargin{:});
     end
     function varargout = setTargetPeriod(self,varargin)
     %Usage: setTargetPeriod (period)
     %
     %period is of type double. 
-      [varargout{1:nargout}] = yarpMEX(2151, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2137, self, varargin{:});
     end
     function self = TypedReaderImageMono16(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/TypedReaderImageRgb.m
+++ b/matlab/autogenerated/+yarp/TypedReaderImageRgb.m
@@ -8,51 +8,51 @@ classdef TypedReaderImageRgb < SwigRef
     function varargout = setStrict(self,varargin)
     %Usage: setStrict ()
     %
-      [varargout{1:nargout}] = yarpMEX(1922, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1908, self, varargin{:});
     end
     function varargout = read(self,varargin)
     %Usage: retval = read ()
     %
     %retval is of type ImageRgb. 
-      [varargout{1:nargout}] = yarpMEX(1923, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1909, self, varargin{:});
     end
     function varargout = interrupt(self,varargin)
     %Usage: interrupt ()
     %
-      [varargout{1:nargout}] = yarpMEX(1924, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1910, self, varargin{:});
     end
     function varargout = lastRead(self,varargin)
     %Usage: retval = lastRead ()
     %
     %retval is of type ImageRgb. 
-      [varargout{1:nargout}] = yarpMEX(1925, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1911, self, varargin{:});
     end
     function varargout = isClosed(self,varargin)
     %Usage: retval = isClosed ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1926, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1912, self, varargin{:});
     end
     function varargout = useCallback(self,varargin)
     %Usage: useCallback (callback)
     %
     %callback is of type TypedReaderCallbackImageRgb. 
-      [varargout{1:nargout}] = yarpMEX(1927, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1913, self, varargin{:});
     end
     function varargout = disableCallback(self,varargin)
     %Usage: disableCallback ()
     %
-      [varargout{1:nargout}] = yarpMEX(1928, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1914, self, varargin{:});
     end
     function varargout = getPendingReads(self,varargin)
     %Usage: retval = getPendingReads ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(1929, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1915, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1930, self);
+        yarpMEX(1916, self);
         self.SwigClear();
       end
     end
@@ -60,31 +60,31 @@ classdef TypedReaderImageRgb < SwigRef
     %Usage: retval = getName ()
     %
     %retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(1931, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1917, self, varargin{:});
     end
     function varargout = setReplier(self,varargin)
     %Usage: setReplier (reader)
     %
     %reader is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(1932, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1918, self, varargin{:});
     end
     function varargout = acquire(self,varargin)
     %Usage: retval = acquire ()
     %
     %retval is of type void *. 
-      [varargout{1:nargout}] = yarpMEX(1933, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1919, self, varargin{:});
     end
     function varargout = release(self,varargin)
     %Usage: release (handle)
     %
     %handle is of type void *. 
-      [varargout{1:nargout}] = yarpMEX(1934, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1920, self, varargin{:});
     end
     function varargout = setTargetPeriod(self,varargin)
     %Usage: setTargetPeriod (period)
     %
     %period is of type double. 
-      [varargout{1:nargout}] = yarpMEX(1935, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1921, self, varargin{:});
     end
     function self = TypedReaderImageRgb(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/TypedReaderImageRgbFloat.m
+++ b/matlab/autogenerated/+yarp/TypedReaderImageRgbFloat.m
@@ -8,51 +8,51 @@ classdef TypedReaderImageRgbFloat < SwigRef
     function varargout = setStrict(self,varargin)
     %Usage: setStrict ()
     %
-      [varargout{1:nargout}] = yarpMEX(2488, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2474, self, varargin{:});
     end
     function varargout = read(self,varargin)
     %Usage: retval = read ()
     %
     %retval is of type ImageRgbFloat. 
-      [varargout{1:nargout}] = yarpMEX(2489, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2475, self, varargin{:});
     end
     function varargout = interrupt(self,varargin)
     %Usage: interrupt ()
     %
-      [varargout{1:nargout}] = yarpMEX(2490, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2476, self, varargin{:});
     end
     function varargout = lastRead(self,varargin)
     %Usage: retval = lastRead ()
     %
     %retval is of type ImageRgbFloat. 
-      [varargout{1:nargout}] = yarpMEX(2491, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2477, self, varargin{:});
     end
     function varargout = isClosed(self,varargin)
     %Usage: retval = isClosed ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2492, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2478, self, varargin{:});
     end
     function varargout = useCallback(self,varargin)
     %Usage: useCallback (callback)
     %
     %callback is of type TypedReaderCallbackImageRgbFloat. 
-      [varargout{1:nargout}] = yarpMEX(2493, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2479, self, varargin{:});
     end
     function varargout = disableCallback(self,varargin)
     %Usage: disableCallback ()
     %
-      [varargout{1:nargout}] = yarpMEX(2494, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2480, self, varargin{:});
     end
     function varargout = getPendingReads(self,varargin)
     %Usage: retval = getPendingReads ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(2495, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2481, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(2496, self);
+        yarpMEX(2482, self);
         self.SwigClear();
       end
     end
@@ -60,31 +60,31 @@ classdef TypedReaderImageRgbFloat < SwigRef
     %Usage: retval = getName ()
     %
     %retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(2497, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2483, self, varargin{:});
     end
     function varargout = setReplier(self,varargin)
     %Usage: setReplier (reader)
     %
     %reader is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(2498, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2484, self, varargin{:});
     end
     function varargout = acquire(self,varargin)
     %Usage: retval = acquire ()
     %
     %retval is of type void *. 
-      [varargout{1:nargout}] = yarpMEX(2499, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2485, self, varargin{:});
     end
     function varargout = release(self,varargin)
     %Usage: release (handle)
     %
     %handle is of type void *. 
-      [varargout{1:nargout}] = yarpMEX(2500, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2486, self, varargin{:});
     end
     function varargout = setTargetPeriod(self,varargin)
     %Usage: setTargetPeriod (period)
     %
     %period is of type double. 
-      [varargout{1:nargout}] = yarpMEX(2501, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2487, self, varargin{:});
     end
     function self = TypedReaderImageRgbFloat(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/TypedReaderImageRgba.m
+++ b/matlab/autogenerated/+yarp/TypedReaderImageRgba.m
@@ -8,51 +8,51 @@ classdef TypedReaderImageRgba < SwigRef
     function varargout = setStrict(self,varargin)
     %Usage: setStrict ()
     %
-      [varargout{1:nargout}] = yarpMEX(1994, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1980, self, varargin{:});
     end
     function varargout = read(self,varargin)
     %Usage: retval = read ()
     %
     %retval is of type ImageRgba. 
-      [varargout{1:nargout}] = yarpMEX(1995, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1981, self, varargin{:});
     end
     function varargout = interrupt(self,varargin)
     %Usage: interrupt ()
     %
-      [varargout{1:nargout}] = yarpMEX(1996, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1982, self, varargin{:});
     end
     function varargout = lastRead(self,varargin)
     %Usage: retval = lastRead ()
     %
     %retval is of type ImageRgba. 
-      [varargout{1:nargout}] = yarpMEX(1997, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1983, self, varargin{:});
     end
     function varargout = isClosed(self,varargin)
     %Usage: retval = isClosed ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1998, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1984, self, varargin{:});
     end
     function varargout = useCallback(self,varargin)
     %Usage: useCallback (callback)
     %
     %callback is of type TypedReaderCallbackImageRgba. 
-      [varargout{1:nargout}] = yarpMEX(1999, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1985, self, varargin{:});
     end
     function varargout = disableCallback(self,varargin)
     %Usage: disableCallback ()
     %
-      [varargout{1:nargout}] = yarpMEX(2000, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1986, self, varargin{:});
     end
     function varargout = getPendingReads(self,varargin)
     %Usage: retval = getPendingReads ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(2001, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1987, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(2002, self);
+        yarpMEX(1988, self);
         self.SwigClear();
       end
     end
@@ -60,31 +60,31 @@ classdef TypedReaderImageRgba < SwigRef
     %Usage: retval = getName ()
     %
     %retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(2003, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1989, self, varargin{:});
     end
     function varargout = setReplier(self,varargin)
     %Usage: setReplier (reader)
     %
     %reader is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(2004, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1990, self, varargin{:});
     end
     function varargout = acquire(self,varargin)
     %Usage: retval = acquire ()
     %
     %retval is of type void *. 
-      [varargout{1:nargout}] = yarpMEX(2005, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1991, self, varargin{:});
     end
     function varargout = release(self,varargin)
     %Usage: release (handle)
     %
     %handle is of type void *. 
-      [varargout{1:nargout}] = yarpMEX(2006, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1992, self, varargin{:});
     end
     function varargout = setTargetPeriod(self,varargin)
     %Usage: setTargetPeriod (period)
     %
     %period is of type double. 
-      [varargout{1:nargout}] = yarpMEX(2007, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1993, self, varargin{:});
     end
     function self = TypedReaderImageRgba(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/TypedReaderProperty.m
+++ b/matlab/autogenerated/+yarp/TypedReaderProperty.m
@@ -8,51 +8,51 @@ classdef TypedReaderProperty < SwigRef
     function varargout = setStrict(self,varargin)
     %Usage: setStrict ()
     %
-      [varargout{1:nargout}] = yarpMEX(727, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(713, self, varargin{:});
     end
     function varargout = read(self,varargin)
     %Usage: retval = read ()
     %
     %retval is of type Property. 
-      [varargout{1:nargout}] = yarpMEX(728, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(714, self, varargin{:});
     end
     function varargout = interrupt(self,varargin)
     %Usage: interrupt ()
     %
-      [varargout{1:nargout}] = yarpMEX(729, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(715, self, varargin{:});
     end
     function varargout = lastRead(self,varargin)
     %Usage: retval = lastRead ()
     %
     %retval is of type Property. 
-      [varargout{1:nargout}] = yarpMEX(730, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(716, self, varargin{:});
     end
     function varargout = isClosed(self,varargin)
     %Usage: retval = isClosed ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(731, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(717, self, varargin{:});
     end
     function varargout = useCallback(self,varargin)
     %Usage: useCallback (callback)
     %
     %callback is of type PropertyCallback. 
-      [varargout{1:nargout}] = yarpMEX(732, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(718, self, varargin{:});
     end
     function varargout = disableCallback(self,varargin)
     %Usage: disableCallback ()
     %
-      [varargout{1:nargout}] = yarpMEX(733, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(719, self, varargin{:});
     end
     function varargout = getPendingReads(self,varargin)
     %Usage: retval = getPendingReads ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(734, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(720, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(735, self);
+        yarpMEX(721, self);
         self.SwigClear();
       end
     end
@@ -60,31 +60,31 @@ classdef TypedReaderProperty < SwigRef
     %Usage: retval = getName ()
     %
     %retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(736, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(722, self, varargin{:});
     end
     function varargout = setReplier(self,varargin)
     %Usage: setReplier (reader)
     %
     %reader is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(737, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(723, self, varargin{:});
     end
     function varargout = acquire(self,varargin)
     %Usage: retval = acquire ()
     %
     %retval is of type void *. 
-      [varargout{1:nargout}] = yarpMEX(738, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(724, self, varargin{:});
     end
     function varargout = release(self,varargin)
     %Usage: release (handle)
     %
     %handle is of type void *. 
-      [varargout{1:nargout}] = yarpMEX(739, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(725, self, varargin{:});
     end
     function varargout = setTargetPeriod(self,varargin)
     %Usage: setTargetPeriod (period)
     %
     %period is of type double. 
-      [varargout{1:nargout}] = yarpMEX(740, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(726, self, varargin{:});
     end
     function self = TypedReaderProperty(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/TypedReaderSound.m
+++ b/matlab/autogenerated/+yarp/TypedReaderSound.m
@@ -8,51 +8,51 @@ classdef TypedReaderSound < SwigRef
     function varargout = setStrict(self,varargin)
     %Usage: setStrict ()
     %
-      [varargout{1:nargout}] = yarpMEX(2277, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2263, self, varargin{:});
     end
     function varargout = read(self,varargin)
     %Usage: retval = read ()
     %
     %retval is of type Sound. 
-      [varargout{1:nargout}] = yarpMEX(2278, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2264, self, varargin{:});
     end
     function varargout = interrupt(self,varargin)
     %Usage: interrupt ()
     %
-      [varargout{1:nargout}] = yarpMEX(2279, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2265, self, varargin{:});
     end
     function varargout = lastRead(self,varargin)
     %Usage: retval = lastRead ()
     %
     %retval is of type Sound. 
-      [varargout{1:nargout}] = yarpMEX(2280, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2266, self, varargin{:});
     end
     function varargout = isClosed(self,varargin)
     %Usage: retval = isClosed ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2281, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2267, self, varargin{:});
     end
     function varargout = useCallback(self,varargin)
     %Usage: useCallback (callback)
     %
     %callback is of type TypedReaderCallbackSound. 
-      [varargout{1:nargout}] = yarpMEX(2282, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2268, self, varargin{:});
     end
     function varargout = disableCallback(self,varargin)
     %Usage: disableCallback ()
     %
-      [varargout{1:nargout}] = yarpMEX(2283, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2269, self, varargin{:});
     end
     function varargout = getPendingReads(self,varargin)
     %Usage: retval = getPendingReads ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(2284, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2270, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(2285, self);
+        yarpMEX(2271, self);
         self.SwigClear();
       end
     end
@@ -60,31 +60,31 @@ classdef TypedReaderSound < SwigRef
     %Usage: retval = getName ()
     %
     %retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(2286, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2272, self, varargin{:});
     end
     function varargout = setReplier(self,varargin)
     %Usage: setReplier (reader)
     %
     %reader is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(2287, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2273, self, varargin{:});
     end
     function varargout = acquire(self,varargin)
     %Usage: retval = acquire ()
     %
     %retval is of type void *. 
-      [varargout{1:nargout}] = yarpMEX(2288, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2274, self, varargin{:});
     end
     function varargout = release(self,varargin)
     %Usage: release (handle)
     %
     %handle is of type void *. 
-      [varargout{1:nargout}] = yarpMEX(2289, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2275, self, varargin{:});
     end
     function varargout = setTargetPeriod(self,varargin)
     %Usage: setTargetPeriod (period)
     %
     %period is of type double. 
-      [varargout{1:nargout}] = yarpMEX(2290, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2276, self, varargin{:});
     end
     function self = TypedReaderSound(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/TypedReaderVector.m
+++ b/matlab/autogenerated/+yarp/TypedReaderVector.m
@@ -8,51 +8,51 @@ classdef TypedReaderVector < SwigRef
     function varargout = setStrict(self,varargin)
     %Usage: setStrict ()
     %
-      [varargout{1:nargout}] = yarpMEX(2342, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2328, self, varargin{:});
     end
     function varargout = read(self,varargin)
     %Usage: retval = read ()
     %
     %retval is of type Vector. 
-      [varargout{1:nargout}] = yarpMEX(2343, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2329, self, varargin{:});
     end
     function varargout = interrupt(self,varargin)
     %Usage: interrupt ()
     %
-      [varargout{1:nargout}] = yarpMEX(2344, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2330, self, varargin{:});
     end
     function varargout = lastRead(self,varargin)
     %Usage: retval = lastRead ()
     %
     %retval is of type Vector. 
-      [varargout{1:nargout}] = yarpMEX(2345, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2331, self, varargin{:});
     end
     function varargout = isClosed(self,varargin)
     %Usage: retval = isClosed ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(2346, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2332, self, varargin{:});
     end
     function varargout = useCallback(self,varargin)
     %Usage: useCallback (callback)
     %
     %callback is of type TypedReaderCallbackVector. 
-      [varargout{1:nargout}] = yarpMEX(2347, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2333, self, varargin{:});
     end
     function varargout = disableCallback(self,varargin)
     %Usage: disableCallback ()
     %
-      [varargout{1:nargout}] = yarpMEX(2348, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2334, self, varargin{:});
     end
     function varargout = getPendingReads(self,varargin)
     %Usage: retval = getPendingReads ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(2349, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2335, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(2350, self);
+        yarpMEX(2336, self);
         self.SwigClear();
       end
     end
@@ -60,31 +60,31 @@ classdef TypedReaderVector < SwigRef
     %Usage: retval = getName ()
     %
     %retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(2351, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2337, self, varargin{:});
     end
     function varargout = setReplier(self,varargin)
     %Usage: setReplier (reader)
     %
     %reader is of type PortReader. 
-      [varargout{1:nargout}] = yarpMEX(2352, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2338, self, varargin{:});
     end
     function varargout = acquire(self,varargin)
     %Usage: retval = acquire ()
     %
     %retval is of type void *. 
-      [varargout{1:nargout}] = yarpMEX(2353, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2339, self, varargin{:});
     end
     function varargout = release(self,varargin)
     %Usage: release (handle)
     %
     %handle is of type void *. 
-      [varargout{1:nargout}] = yarpMEX(2354, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2340, self, varargin{:});
     end
     function varargout = setTargetPeriod(self,varargin)
     %Usage: setTargetPeriod (period)
     %
     %period is of type double. 
-      [varargout{1:nargout}] = yarpMEX(2355, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(2341, self, varargin{:});
     end
     function self = TypedReaderVector(varargin)
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')

--- a/matlab/autogenerated/+yarp/UnbufferedContactable.m
+++ b/matlab/autogenerated/+yarp/UnbufferedContactable.m
@@ -1,10 +1,7 @@
-classdef UnbufferedContactable < SwigRef
+classdef UnbufferedContactable < yarp.Contactable
     %Usage: UnbufferedContactable ()
     %
   methods
-    function this = swig_this(self)
-      this = yarpMEX(3, self);
-    end
     function varargout = write(self,varargin)
     %Usage: retval = write (writer, reader)
     %
@@ -36,6 +33,7 @@ classdef UnbufferedContactable < SwigRef
       end
     end
     function self = UnbufferedContactable(varargin)
+      self@yarp.Contactable(SwigRef.Null);
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;

--- a/matlab/autogenerated/+yarp/UnbufferedContactable.m
+++ b/matlab/autogenerated/+yarp/UnbufferedContactable.m
@@ -6,29 +6,29 @@ classdef UnbufferedContactable < yarp.Contactable
     %Usage: retval = write (writer, reader)
     %
     %writer is of type PortWriter. reader is of type PortReader. writer is of type PortWriter. reader is of type PortReader. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(254, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(242, self, varargin{:});
     end
     function varargout = read(self,varargin)
     %Usage: retval = read (reader)
     %
     %reader is of type PortReader. reader is of type PortReader. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(255, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(243, self, varargin{:});
     end
     function varargout = reply(self,varargin)
     %Usage: retval = reply (writer)
     %
     %writer is of type PortWriter. writer is of type PortWriter. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(256, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(244, self, varargin{:});
     end
     function varargout = replyAndDrop(self,varargin)
     %Usage: retval = replyAndDrop (writer)
     %
     %writer is of type PortWriter. writer is of type PortWriter. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(257, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(245, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(258, self);
+        yarpMEX(246, self);
         self.SwigClear();
       end
     end

--- a/matlab/autogenerated/+yarp/Value.m
+++ b/matlab/autogenerated/+yarp/Value.m
@@ -1,4 +1,4 @@
-classdef Value < SwigRef
+classdef Value < yarp.Portable & yarp.Searchable
     %Usage: Value ()
     %
   methods
@@ -6,6 +6,8 @@ classdef Value < SwigRef
       this = yarpMEX(3, self);
     end
     function self = Value(varargin)
+      self@yarp.Portable(SwigRef.Null);
+      self@yarp.Searchable(SwigRef.Null);
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;

--- a/matlab/autogenerated/+yarp/Value.m
+++ b/matlab/autogenerated/+yarp/Value.m
@@ -13,14 +13,14 @@ classdef Value < yarp.Portable & yarp.Searchable
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(154, varargin{:});
+        tmp = yarpMEX(142, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(155, self);
+        yarpMEX(143, self);
         self.SwigClear();
       end
     end
@@ -28,271 +28,271 @@ classdef Value < yarp.Portable & yarp.Searchable
     %Usage: retval = isBool ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(156, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(144, self, varargin{:});
     end
     function varargout = isInt(self,varargin)
     %Usage: retval = isInt ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(157, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(145, self, varargin{:});
     end
     function varargout = isInt8(self,varargin)
     %Usage: retval = isInt8 ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(158, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(146, self, varargin{:});
     end
     function varargout = isInt16(self,varargin)
     %Usage: retval = isInt16 ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(159, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(147, self, varargin{:});
     end
     function varargout = isInt32(self,varargin)
     %Usage: retval = isInt32 ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(160, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(148, self, varargin{:});
     end
     function varargout = isInt64(self,varargin)
     %Usage: retval = isInt64 ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(161, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(149, self, varargin{:});
     end
     function varargout = isDouble(self,varargin)
     %Usage: retval = isDouble ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(162, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(150, self, varargin{:});
     end
     function varargout = isFloat32(self,varargin)
     %Usage: retval = isFloat32 ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(163, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(151, self, varargin{:});
     end
     function varargout = isFloat64(self,varargin)
     %Usage: retval = isFloat64 ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(164, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(152, self, varargin{:});
     end
     function varargout = isString(self,varargin)
     %Usage: retval = isString ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(165, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(153, self, varargin{:});
     end
     function varargout = isList(self,varargin)
     %Usage: retval = isList ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(166, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(154, self, varargin{:});
     end
     function varargout = isDict(self,varargin)
     %Usage: retval = isDict ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(167, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(155, self, varargin{:});
     end
     function varargout = isVocab(self,varargin)
     %Usage: retval = isVocab ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(168, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(156, self, varargin{:});
     end
     function varargout = isBlob(self,varargin)
     %Usage: retval = isBlob ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(169, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(157, self, varargin{:});
     end
     function varargout = asBool(self,varargin)
     %Usage: retval = asBool ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(170, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(158, self, varargin{:});
     end
     function varargout = asInt(self,varargin)
     %Usage: retval = asInt ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(171, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(159, self, varargin{:});
     end
     function varargout = asInt8(self,varargin)
     %Usage: retval = asInt8 ()
     %
     %retval is of type std::int8_t. 
-      [varargout{1:nargout}] = yarpMEX(172, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(160, self, varargin{:});
     end
     function varargout = asInt16(self,varargin)
     %Usage: retval = asInt16 ()
     %
     %retval is of type std::int16_t. 
-      [varargout{1:nargout}] = yarpMEX(173, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(161, self, varargin{:});
     end
     function varargout = asInt32(self,varargin)
     %Usage: retval = asInt32 ()
     %
     %retval is of type std::int32_t. 
-      [varargout{1:nargout}] = yarpMEX(174, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(162, self, varargin{:});
     end
     function varargout = asInt64(self,varargin)
     %Usage: retval = asInt64 ()
     %
     %retval is of type std::int64_t. 
-      [varargout{1:nargout}] = yarpMEX(175, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(163, self, varargin{:});
     end
     function varargout = asDouble(self,varargin)
     %Usage: retval = asDouble ()
     %
     %retval is of type double. 
-      [varargout{1:nargout}] = yarpMEX(176, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(164, self, varargin{:});
     end
     function varargout = asFloat32(self,varargin)
     %Usage: retval = asFloat32 ()
     %
     %retval is of type yarp::conf::float32_t. 
-      [varargout{1:nargout}] = yarpMEX(177, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(165, self, varargin{:});
     end
     function varargout = asFloat64(self,varargin)
     %Usage: retval = asFloat64 ()
     %
     %retval is of type yarp::conf::float64_t. 
-      [varargout{1:nargout}] = yarpMEX(178, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(166, self, varargin{:});
     end
     function varargout = asVocab(self,varargin)
     %Usage: retval = asVocab ()
     %
     %retval is of type std::int32_t. 
-      [varargout{1:nargout}] = yarpMEX(179, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(167, self, varargin{:});
     end
     function varargout = asString(self,varargin)
     %Usage: retval = asString ()
     %
     %retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(180, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(168, self, varargin{:});
     end
     function varargout = asList(self,varargin)
     %Usage: retval = asList ()
     %
     %retval is of type Bottle. 
-      [varargout{1:nargout}] = yarpMEX(181, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(169, self, varargin{:});
     end
     function varargout = asDict(self,varargin)
     %Usage: retval = asDict ()
     %
     %retval is of type Property. 
-      [varargout{1:nargout}] = yarpMEX(182, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(170, self, varargin{:});
     end
     function varargout = asSearchable(self,varargin)
     %Usage: retval = asSearchable ()
     %
     %retval is of type Searchable. 
-      [varargout{1:nargout}] = yarpMEX(183, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(171, self, varargin{:});
     end
     function varargout = asBlob(self,varargin)
     %Usage: retval = asBlob ()
     %
     %retval is of type char const *. 
-      [varargout{1:nargout}] = yarpMEX(184, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(172, self, varargin{:});
     end
     function varargout = asBlobLength(self,varargin)
     %Usage: retval = asBlobLength ()
     %
     %retval is of type size_t. 
-      [varargout{1:nargout}] = yarpMEX(185, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(173, self, varargin{:});
     end
     function varargout = read(self,varargin)
     %Usage: retval = read (connection)
     %
     %connection is of type ConnectionReader. connection is of type ConnectionReader. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(186, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(174, self, varargin{:});
     end
     function varargout = write(self,varargin)
     %Usage: retval = write (connection)
     %
     %connection is of type ConnectionWriter. connection is of type ConnectionWriter. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(187, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(175, self, varargin{:});
     end
     function varargout = check(self,varargin)
     %Usage: retval = check (key)
     %
     %key is of type std::string const &. key is of type std::string const &. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(188, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(176, self, varargin{:});
     end
     function varargout = find(self,varargin)
     %Usage: retval = find (key)
     %
     %key is of type std::string const &. key is of type std::string const &. retval is of type Value. 
-      [varargout{1:nargout}] = yarpMEX(189, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(177, self, varargin{:});
     end
     function varargout = findGroup(self,varargin)
     %Usage: retval = findGroup (key)
     %
     %key is of type std::string const &. key is of type std::string const &. retval is of type Bottle. 
-      [varargout{1:nargout}] = yarpMEX(190, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(178, self, varargin{:});
     end
     function varargout = isEqual(self,varargin)
     %Usage: retval = isEqual (alt)
     %
-    %alt is of type char const *. alt is of type char const *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(191, self, varargin{:});
+    %alt is of type Value. alt is of type Value. retval is of type bool. 
+      [varargout{1:nargout}] = yarpMEX(179, self, varargin{:});
     end
     function varargout = notEqual(self,varargin)
     %Usage: retval = notEqual (alt)
     %
-    %alt is of type char const *. alt is of type char const *. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(192, self, varargin{:});
+    %alt is of type Value. alt is of type Value. retval is of type bool. 
+      [varargout{1:nargout}] = yarpMEX(180, self, varargin{:});
     end
     function varargout = fromString(self,varargin)
     %Usage: fromString (str)
     %
     %str is of type char const *. 
-      [varargout{1:nargout}] = yarpMEX(193, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(181, self, varargin{:});
     end
     function varargout = toString_c(self,varargin)
     %Usage: retval = toString_c ()
     %
     %retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(194, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(182, self, varargin{:});
     end
     function varargout = create(self,varargin)
     %Usage: retval = create ()
     %
     %retval is of type Value. 
-      [varargout{1:nargout}] = yarpMEX(195, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(183, self, varargin{:});
     end
     function varargout = clone(self,varargin)
     %Usage: retval = clone ()
     %
     %retval is of type Value. 
-      [varargout{1:nargout}] = yarpMEX(196, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(184, self, varargin{:});
     end
     function varargout = getCode(self,varargin)
     %Usage: retval = getCode ()
     %
     %retval is of type std::int32_t. 
-      [varargout{1:nargout}] = yarpMEX(197, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(185, self, varargin{:});
     end
     function varargout = isNull(self,varargin)
     %Usage: retval = isNull ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(198, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(186, self, varargin{:});
     end
     function varargout = isLeaf(self,varargin)
     %Usage: retval = isLeaf ()
     %
     %retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(199, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(187, self, varargin{:});
     end
     function varargout = toString(self,varargin)
     %Usage: retval = toString ()
     %
     %retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(214, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(202, self, varargin{:});
     end
   end
   methods(Static)
@@ -300,85 +300,85 @@ classdef Value < yarp.Portable & yarp.Searchable
     %Usage: retval = makeInt (x)
     %
     %x is of type int. x is of type int. retval is of type Value. 
-     [varargout{1:nargout}] = yarpMEX(200, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(188, varargin{:});
     end
     function varargout = makeInt8(varargin)
     %Usage: retval = makeInt8 (x)
     %
     %x is of type std::int8_t. x is of type std::int8_t. retval is of type Value. 
-     [varargout{1:nargout}] = yarpMEX(201, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(189, varargin{:});
     end
     function varargout = makeInt16(varargin)
     %Usage: retval = makeInt16 (x)
     %
     %x is of type std::int16_t. x is of type std::int16_t. retval is of type Value. 
-     [varargout{1:nargout}] = yarpMEX(202, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(190, varargin{:});
     end
     function varargout = makeInt32(varargin)
     %Usage: retval = makeInt32 (x)
     %
     %x is of type std::int32_t. x is of type std::int32_t. retval is of type Value. 
-     [varargout{1:nargout}] = yarpMEX(203, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(191, varargin{:});
     end
     function varargout = makeInt64(varargin)
     %Usage: retval = makeInt64 (x)
     %
     %x is of type std::int64_t. x is of type std::int64_t. retval is of type Value. 
-     [varargout{1:nargout}] = yarpMEX(204, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(192, varargin{:});
     end
     function varargout = makeDouble(varargin)
     %Usage: retval = makeDouble (x)
     %
     %x is of type double. x is of type double. retval is of type Value. 
-     [varargout{1:nargout}] = yarpMEX(205, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(193, varargin{:});
     end
     function varargout = makeFloat32(varargin)
     %Usage: retval = makeFloat32 (x)
     %
     %x is of type yarp::conf::float32_t. x is of type yarp::conf::float32_t. retval is of type Value. 
-     [varargout{1:nargout}] = yarpMEX(206, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(194, varargin{:});
     end
     function varargout = makeFloat64(varargin)
     %Usage: retval = makeFloat64 (x)
     %
     %x is of type yarp::conf::float64_t. x is of type yarp::conf::float64_t. retval is of type Value. 
-     [varargout{1:nargout}] = yarpMEX(207, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(195, varargin{:});
     end
     function varargout = makeString(varargin)
     %Usage: retval = makeString (str)
     %
     %str is of type std::string const &. str is of type std::string const &. retval is of type Value. 
-     [varargout{1:nargout}] = yarpMEX(208, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(196, varargin{:});
     end
     function varargout = makeVocab(varargin)
     %Usage: retval = makeVocab (str)
     %
     %str is of type std::string const &. str is of type std::string const &. retval is of type Value. 
-     [varargout{1:nargout}] = yarpMEX(209, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(197, varargin{:});
     end
     function varargout = makeBlob(varargin)
     %Usage: retval = makeBlob (data, length)
     %
     %data is of type void *. length is of type int. data is of type void *. length is of type int. retval is of type Value. 
-     [varargout{1:nargout}] = yarpMEX(210, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(198, varargin{:});
     end
     function varargout = makeList(varargin)
     %Usage: retval = makeList (txt)
     %
     %txt is of type char const *. txt is of type char const *. retval is of type Value. 
-     [varargout{1:nargout}] = yarpMEX(211, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(199, varargin{:});
     end
     function varargout = makeValue(varargin)
     %Usage: retval = makeValue (txt)
     %
     %txt is of type std::string const &. txt is of type std::string const &. retval is of type Value. 
-     [varargout{1:nargout}] = yarpMEX(212, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(200, varargin{:});
     end
     function varargout = getNullValue(varargin)
     %Usage: retval = getNullValue ()
     %
     %retval is of type Value. 
-     [varargout{1:nargout}] = yarpMEX(213, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(201, varargin{:});
     end
   end
 end

--- a/matlab/autogenerated/+yarp/Vector.m
+++ b/matlab/autogenerated/+yarp/Vector.m
@@ -4,7 +4,7 @@ classdef Vector < yarp.Portable
   methods
     function delete(self)
       if self.swigPtr
-        yarpMEX(1028, self);
+        yarpMEX(1014, self);
         self.SwigClear();
       end
     end
@@ -15,7 +15,7 @@ classdef Vector < yarp.Portable
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(1029, varargin{:});
+        tmp = yarpMEX(1015, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
@@ -24,112 +24,112 @@ classdef Vector < yarp.Portable
     %Usage: resize (size, def)
     %
     %size is of type size_t. def is of type double const &. 
-      [varargout{1:nargout}] = yarpMEX(1030, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1016, self, varargin{:});
     end
     function varargout = size(self,varargin)
     %Usage: retval = size ()
     %
     %retval is of type size_t. 
-      [varargout{1:nargout}] = yarpMEX(1031, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1017, self, varargin{:});
     end
     function varargout = length(self,varargin)
     %Usage: retval = length ()
     %
     %retval is of type size_t. 
-      [varargout{1:nargout}] = yarpMEX(1032, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1018, self, varargin{:});
     end
     function varargout = zero(self,varargin)
     %Usage: zero ()
     %
-      [varargout{1:nargout}] = yarpMEX(1033, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1019, self, varargin{:});
     end
     function varargout = toString(self,varargin)
     %Usage: retval = toString (precision = -1)
     %
     %precision is of type int. precision is of type int. retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(1034, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1020, self, varargin{:});
     end
     function varargout = toString_c(self,varargin)
     %Usage: retval = toString_c ()
     %
     %retval is of type std::string. 
-      [varargout{1:nargout}] = yarpMEX(1035, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1021, self, varargin{:});
     end
     function varargout = subVector(self,varargin)
     %Usage: retval = subVector (first, last)
     %
     %first is of type unsigned int. last is of type unsigned int. first is of type unsigned int. last is of type unsigned int. retval is of type Vector. 
-      [varargout{1:nargout}] = yarpMEX(1036, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1022, self, varargin{:});
     end
     function varargout = setSubvector(self,varargin)
     %Usage: retval = setSubvector (position, v)
     %
     %position is of type int. v is of type Vector. position is of type int. v is of type Vector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1037, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1023, self, varargin{:});
     end
     function varargout = data(self,varargin)
     %Usage: retval = data ()
     %
     %retval is of type double const *. 
-      [varargout{1:nargout}] = yarpMEX(1038, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1024, self, varargin{:});
     end
     function varargout = isEqual(self,varargin)
     %Usage: retval = isEqual (r)
     %
     %r is of type Vector. r is of type Vector. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1039, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1025, self, varargin{:});
     end
     function varargout = push_back(self,varargin)
     %Usage: push_back (elem)
     %
     %elem is of type double const &. 
-      [varargout{1:nargout}] = yarpMEX(1040, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1026, self, varargin{:});
     end
     function varargout = pop_back(self,varargin)
     %Usage: pop_back ()
     %
-      [varargout{1:nargout}] = yarpMEX(1041, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1027, self, varargin{:});
     end
     function varargout = brace(self,varargin)
     %Usage: retval = brace (i)
     %
     %i is of type size_t. i is of type size_t. retval is of type double const &. 
-      [varargout{1:nargout}] = yarpMEX(1042, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1028, self, varargin{:});
     end
     function varargout = access(self,varargin)
     %Usage: retval = access (i)
     %
     %i is of type size_t. i is of type size_t. retval is of type double const &. 
-      [varargout{1:nargout}] = yarpMEX(1043, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1029, self, varargin{:});
     end
     function varargout = clear(self,varargin)
     %Usage: clear ()
     %
-      [varargout{1:nargout}] = yarpMEX(1044, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1030, self, varargin{:});
     end
     function varargout = read(self,varargin)
     %Usage: retval = read (connection)
     %
     %connection is of type ConnectionReader. connection is of type ConnectionReader. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1045, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1031, self, varargin{:});
     end
     function varargout = write(self,varargin)
     %Usage: retval = write (connection)
     %
     %connection is of type ConnectionWriter. connection is of type ConnectionWriter. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1046, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1032, self, varargin{:});
     end
     function varargout = get(self,varargin)
     %Usage: retval = get (j)
     %
     %j is of type int. j is of type int. retval is of type double. 
-      [varargout{1:nargout}] = yarpMEX(1047, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1033, self, varargin{:});
     end
     function varargout = set(self,varargin)
     %Usage: set (j, v)
     %
     %j is of type int. v is of type double. 
-      [varargout{1:nargout}] = yarpMEX(1048, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1034, self, varargin{:});
     end
   end
   methods(Static)

--- a/matlab/autogenerated/+yarp/Vector.m
+++ b/matlab/autogenerated/+yarp/Vector.m
@@ -1,10 +1,7 @@
-classdef Vector < SwigRef
+classdef Vector < yarp.Portable
     %Usage: Vector ()
     %
   methods
-    function this = swig_this(self)
-      this = yarpMEX(3, self);
-    end
     function delete(self)
       if self.swigPtr
         yarpMEX(1028, self);
@@ -12,6 +9,7 @@ classdef Vector < SwigRef
       end
     end
     function self = Vector(varargin)
+      self@yarp.Portable(SwigRef.Null);
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;

--- a/matlab/autogenerated/+yarp/VectorBase.m
+++ b/matlab/autogenerated/+yarp/VectorBase.m
@@ -1,10 +1,7 @@
-classdef VectorBase < SwigRef
+classdef VectorBase < yarp.Portable
     %Usage: VectorBase ()
     %
   methods
-    function this = swig_this(self)
-      this = yarpMEX(3, self);
-    end
     function varargout = getElementSize(self,varargin)
     %Usage: retval = getElementSize ()
     %
@@ -54,6 +51,7 @@ classdef VectorBase < SwigRef
       end
     end
     function self = VectorBase(varargin)
+      self@yarp.Portable(SwigRef.Null);
       if nargin==1 && strcmp(class(varargin{1}),'SwigRef')
         if ~isnull(varargin{1})
           self.swigPtr = varargin{1}.swigPtr;

--- a/matlab/autogenerated/+yarp/VectorBase.m
+++ b/matlab/autogenerated/+yarp/VectorBase.m
@@ -6,47 +6,47 @@ classdef VectorBase < yarp.Portable
     %Usage: retval = getElementSize ()
     %
     %retval is of type size_t. 
-      [varargout{1:nargout}] = yarpMEX(1020, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1006, self, varargin{:});
     end
     function varargout = getBottleTag(self,varargin)
     %Usage: retval = getBottleTag ()
     %
     %retval is of type int. 
-      [varargout{1:nargout}] = yarpMEX(1021, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1007, self, varargin{:});
     end
     function varargout = getListSize(self,varargin)
     %Usage: retval = getListSize ()
     %
     %retval is of type size_t. 
-      [varargout{1:nargout}] = yarpMEX(1022, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1008, self, varargin{:});
     end
     function varargout = getMemoryBlock(self,varargin)
     %Usage: retval = getMemoryBlock ()
     %
-    %retval is of type char const *. 
-      [varargout{1:nargout}] = yarpMEX(1023, self, varargin{:});
+    %retval is of type char *. 
+      [varargout{1:nargout}] = yarpMEX(1009, self, varargin{:});
     end
     function varargout = resize(self,varargin)
     %Usage: resize (size)
     %
     %size is of type size_t. 
-      [varargout{1:nargout}] = yarpMEX(1024, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1010, self, varargin{:});
     end
     function varargout = read(self,varargin)
     %Usage: retval = read (connection)
     %
     %connection is of type ConnectionReader. connection is of type ConnectionReader. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1025, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1011, self, varargin{:});
     end
     function varargout = write(self,varargin)
     %Usage: retval = write (connection)
     %
     %connection is of type ConnectionWriter. connection is of type ConnectionWriter. retval is of type bool. 
-      [varargout{1:nargout}] = yarpMEX(1026, self, varargin{:});
+      [varargout{1:nargout}] = yarpMEX(1012, self, varargin{:});
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(1027, self);
+        yarpMEX(1013, self);
         self.SwigClear();
       end
     end

--- a/matlab/autogenerated/+yarp/Vocab.m
+++ b/matlab/autogenerated/+yarp/Vocab.m
@@ -11,14 +11,14 @@ classdef Vocab < SwigRef
           self.swigPtr = varargin{1}.swigPtr;
         end
       else
-        tmp = yarpMEX(217, varargin{:});
+        tmp = yarpMEX(205, varargin{:});
         self.swigPtr = tmp.swigPtr;
         tmp.SwigClear();
       end
     end
     function delete(self)
       if self.swigPtr
-        yarpMEX(218, self);
+        yarpMEX(206, self);
         self.SwigClear();
       end
     end
@@ -28,13 +28,13 @@ classdef Vocab < SwigRef
     %Usage: retval = encode (str)
     %
     %str is of type std::string const &. str is of type std::string const &. retval is of type yarp::os::NetInt32. 
-     [varargout{1:nargout}] = yarpMEX(215, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(203, varargin{:});
     end
     function varargout = decode(varargin)
     %Usage: retval = decode (code)
     %
     %code is of type yarp::os::NetInt32. code is of type yarp::os::NetInt32. retval is of type std::string. 
-     [varargout{1:nargout}] = yarpMEX(216, varargin{:});
+     [varargout{1:nargout}] = yarpMEX(204, varargin{:});
     end
   end
 end

--- a/matlab/autogenerated/+yarp/clockTypeToString.m
+++ b/matlab/autogenerated/+yarp/clockTypeToString.m
@@ -2,5 +2,5 @@ function varargout = clockTypeToString(varargin)
     %Usage: retval = clockTypeToString (type)
     %
     %type is of type yarp::os::yarpClockType. type is of type yarp::os::yarpClockType. retval is of type std::string. 
-  [varargout{1:nargout}] = yarpMEX(568, varargin{:});
+  [varargout{1:nargout}] = yarpMEX(556, varargin{:});
 end

--- a/matlab/autogenerated/+yarp/delay.m
+++ b/matlab/autogenerated/+yarp/delay.m
@@ -2,5 +2,5 @@ function varargout = delay(varargin)
     %Usage: delay (seconds)
     %
     %seconds is of type double. 
-  [varargout{1:nargout}] = yarpMEX(558, varargin{:});
+  [varargout{1:nargout}] = yarpMEX(546, varargin{:});
 end

--- a/matlab/autogenerated/+yarp/getClockType.m
+++ b/matlab/autogenerated/+yarp/getClockType.m
@@ -2,5 +2,5 @@ function varargout = getClockType(varargin)
     %Usage: retval = getClockType ()
     %
     %retval is of type yarp::os::yarpClockType. 
-  [varargout{1:nargout}] = yarpMEX(567, varargin{:});
+  [varargout{1:nargout}] = yarpMEX(555, varargin{:});
 end

--- a/matlab/autogenerated/+yarp/isCustomClock.m
+++ b/matlab/autogenerated/+yarp/isCustomClock.m
@@ -2,5 +2,5 @@ function varargout = isCustomClock(varargin)
     %Usage: retval = isCustomClock ()
     %
     %retval is of type bool. 
-  [varargout{1:nargout}] = yarpMEX(566, varargin{:});
+  [varargout{1:nargout}] = yarpMEX(554, varargin{:});
 end

--- a/matlab/autogenerated/+yarp/isNetworkClock.m
+++ b/matlab/autogenerated/+yarp/isNetworkClock.m
@@ -2,5 +2,5 @@ function varargout = isNetworkClock(varargin)
     %Usage: retval = isNetworkClock ()
     %
     %retval is of type bool. 
-  [varargout{1:nargout}] = yarpMEX(565, varargin{:});
+  [varargout{1:nargout}] = yarpMEX(553, varargin{:});
 end

--- a/matlab/autogenerated/+yarp/isSystemClock.m
+++ b/matlab/autogenerated/+yarp/isSystemClock.m
@@ -2,5 +2,5 @@ function varargout = isSystemClock(varargin)
     %Usage: retval = isSystemClock ()
     %
     %retval is of type bool. 
-  [varargout{1:nargout}] = yarpMEX(564, varargin{:});
+  [varargout{1:nargout}] = yarpMEX(552, varargin{:});
 end

--- a/matlab/autogenerated/+yarp/isValid.m
+++ b/matlab/autogenerated/+yarp/isValid.m
@@ -2,5 +2,5 @@ function varargout = isValid(varargin)
     %Usage: retval = isValid ()
     %
     %retval is of type bool. 
-  [varargout{1:nargout}] = yarpMEX(569, varargin{:});
+  [varargout{1:nargout}] = yarpMEX(557, varargin{:});
 end

--- a/matlab/autogenerated/+yarp/now.m
+++ b/matlab/autogenerated/+yarp/now.m
@@ -2,5 +2,5 @@ function varargout = now(varargin)
     %Usage: retval = now ()
     %
     %retval is of type double. 
-  [varargout{1:nargout}] = yarpMEX(559, varargin{:});
+  [varargout{1:nargout}] = yarpMEX(547, varargin{:});
 end

--- a/matlab/autogenerated/+yarp/read.m
+++ b/matlab/autogenerated/+yarp/read.m
@@ -2,5 +2,5 @@ function varargout = read(varargin)
     %Usage: retval = read (dest, src)
     %
     %dest is of type ImageFloat. src is of type std::string const &. dest is of type ImageFloat. src is of type std::string const &. retval is of type bool. 
-  [varargout{1:nargout}] = yarpMEX(965, varargin{:});
+  [varargout{1:nargout}] = yarpMEX(951, varargin{:});
 end

--- a/matlab/autogenerated/+yarp/removeCols.m
+++ b/matlab/autogenerated/+yarp/removeCols.m
@@ -2,5 +2,5 @@ function varargout = removeCols(varargin)
     %Usage: retval = removeCols (in, out, first_col, how_many)
     %
     %in is of type Matrix. out is of type Matrix. first_col is of type size_t. how_many is of type size_t. in is of type Matrix. out is of type Matrix. first_col is of type size_t. how_many is of type size_t. retval is of type bool. 
-  [varargout{1:nargout}] = yarpMEX(987, varargin{:});
+  [varargout{1:nargout}] = yarpMEX(973, varargin{:});
 end

--- a/matlab/autogenerated/+yarp/removeRows.m
+++ b/matlab/autogenerated/+yarp/removeRows.m
@@ -2,5 +2,5 @@ function varargout = removeRows(varargin)
     %Usage: retval = removeRows (in, out, first_row, how_many)
     %
     %in is of type Matrix. out is of type Matrix. first_row is of type size_t. how_many is of type size_t. in is of type Matrix. out is of type Matrix. first_row is of type size_t. how_many is of type size_t. retval is of type bool. 
-  [varargout{1:nargout}] = yarpMEX(988, varargin{:});
+  [varargout{1:nargout}] = yarpMEX(974, varargin{:});
 end

--- a/matlab/autogenerated/+yarp/submatrix.m
+++ b/matlab/autogenerated/+yarp/submatrix.m
@@ -2,5 +2,5 @@ function varargout = submatrix(varargin)
     %Usage: retval = submatrix (in, out, r1, r2, c1, c2)
     %
     %in is of type Matrix. out is of type Matrix. r1 is of type size_t. r2 is of type size_t. c1 is of type size_t. c2 is of type size_t. in is of type Matrix. out is of type Matrix. r1 is of type size_t. r2 is of type size_t. c1 is of type size_t. c2 is of type size_t. retval is of type bool. 
-  [varargout{1:nargout}] = yarpMEX(986, varargin{:});
+  [varargout{1:nargout}] = yarpMEX(972, varargin{:});
 end

--- a/matlab/autogenerated/+yarp/turboBoost.m
+++ b/matlab/autogenerated/+yarp/turboBoost.m
@@ -1,5 +1,5 @@
 function varargout = turboBoost(varargin)
     %Usage: turboBoost ()
     %
-  [varargout{1:nargout}] = yarpMEX(570, varargin{:});
+  [varargout{1:nargout}] = yarpMEX(558, varargin{:});
 end

--- a/matlab/autogenerated/+yarp/useCustomClock.m
+++ b/matlab/autogenerated/+yarp/useCustomClock.m
@@ -2,5 +2,5 @@ function varargout = useCustomClock(varargin)
     %Usage: useCustomClock (clock)
     %
     %clock is of type Clock *. 
-  [varargout{1:nargout}] = yarpMEX(563, varargin{:});
+  [varargout{1:nargout}] = yarpMEX(551, varargin{:});
 end

--- a/matlab/autogenerated/+yarp/useNetworkClock.m
+++ b/matlab/autogenerated/+yarp/useNetworkClock.m
@@ -2,5 +2,5 @@ function varargout = useNetworkClock(varargin)
     %Usage: useNetworkClock (clock)
     %
     %clock is of type std::string const &. 
-  [varargout{1:nargout}] = yarpMEX(562, varargin{:});
+  [varargout{1:nargout}] = yarpMEX(550, varargin{:});
 end

--- a/matlab/autogenerated/+yarp/useSystemClock.m
+++ b/matlab/autogenerated/+yarp/useSystemClock.m
@@ -1,5 +1,5 @@
 function varargout = useSystemClock(varargin)
     %Usage: useSystemClock ()
     %
-  [varargout{1:nargout}] = yarpMEX(561, varargin{:});
+  [varargout{1:nargout}] = yarpMEX(549, varargin{:});
 end

--- a/matlab/autogenerated/+yarp/write.m
+++ b/matlab/autogenerated/+yarp/write.m
@@ -2,5 +2,5 @@ function varargout = write(varargin)
     %Usage: retval = write (src, dest)
     %
     %src is of type Image. dest is of type std::string const &. src is of type Image. dest is of type std::string const &. retval is of type bool. 
-  [varargout{1:nargout}] = yarpMEX(966, varargin{:});
+  [varargout{1:nargout}] = yarpMEX(952, varargin{:});
 end

--- a/matlab/autogenerated/+yarp/yarp_print_trace.m
+++ b/matlab/autogenerated/+yarp/yarp_print_trace.m
@@ -2,5 +2,5 @@ function varargout = yarp_print_trace(varargin)
     %Usage: yarp_print_trace (out, file, line)
     %
     %out is of type FILE *. file is of type char const *. line is of type int. 
-  [varargout{1:nargout}] = yarpMEX(724, varargin{:});
+  [varargout{1:nargout}] = yarpMEX(710, varargin{:});
 end

--- a/matlab/autogenerated/+yarp/yield.m
+++ b/matlab/autogenerated/+yarp/yield.m
@@ -1,5 +1,5 @@
 function varargout = yield(varargin)
     %Usage: yield ()
     %
-  [varargout{1:nargout}] = yarpMEX(560, varargin{:});
+  [varargout{1:nargout}] = yarpMEX(548, varargin{:});
 end


### PR DESCRIPTION
Regenerated the bindings after fixing SWIG issue https://github.com/robotology-dependencies/swig/issues/3 (super-classes were replaced by swig ref class) : 

- YARP commit (devel) : `50c6677bf126ea88259eb9f4d77334bc45e2f464`
- SWIG commit (matlab): `7e61db6b5dc841027439081aed3bf8c36c9e1920`

Regenerated the bindings up to date with Yarp 3.0.0 : 

- YARP commit (devel) : `075cd3955ce24dfd1efcffd1297b18a719276d8b`
- SWIG commit (matlab): `7e61db6b5dc841027439081aed3bf8c36c9e1920`